### PR TITLE
chore: 🤖 Changed test to include linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "bootstrap": "lerna bootstrap --use-workspaces",
     "lint": "lerna run lint --parallel",
     "lint:fix": "lerna run lint:fix --parallel",
-    "test": "jest"
+    "test:dev": "jest --watchAll",
+    "test": "yarn lint && jest"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",


### PR DESCRIPTION
In order to make contributing easier, the test command now also runs
lint. If you want a continuous test runner for development, run `yarn
test:dev`