### PR TITLE
fix: 🐛 including types in build

### DIFF
--- a/libs/react/src/index.ts
+++ b/libs/react/src/index.ts
@@ -11,6 +11,7 @@ export * from './lib/stepper/stepper'
 export * from './lib/select'
 export * from './lib/dropdown/dropdown'
 export * from './lib/datepicker/datepicker'
+export * from './types'
 
 // Backwards compatibility export
 export { AlertRibbon as Alert } from './lib/alert-ribbon/alert-ribbon'

--- a/libs/react/src/lib/select/select.tsx
+++ b/libs/react/src/lib/select/select.tsx
@@ -6,6 +6,7 @@ import {
   validateClassName,
 } from '@sebgroup/extract'
 import { ChevronDown } from '../icons'
+import { SelectorAttributesProps, LabelProps } from '../../types'
 
 export interface SelectProps extends SelectorAttributesProps, LabelProps {
   children: ReactNode

--- a/libs/react/src/types/index.ts
+++ b/libs/react/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './props'

--- a/libs/react/src/types/props/index.ts
+++ b/libs/react/src/types/props/index.ts
@@ -1,10 +1,10 @@
-interface SelectorAttributesProps {
+export interface SelectorAttributesProps {
   id?: string
   className?: string
   testId?: string
 }
 
-interface LabelProps {
+export interface LabelProps {
   label?: string
   labelInformation?: string
 }


### PR DESCRIPTION
Types were added incorrect and weren't included in build. They are now exported correctly and included.