### PR TITLE
fix: 🐛 pagination shouldn't exceed totalPages on length change

### DIFF
--- a/libs/angular/src/lib/pagination/pagination.component.ts
+++ b/libs/angular/src/lib/pagination/pagination.component.ts
@@ -71,6 +71,10 @@ export class NggPaginationComponent implements OnChanges {
     ) {
       this._pageIndicies = this.getDisplayedPageIndicies()
     }
+
+    if (changes.length && this.pageIndex >= this.totalPages) {
+      this.goto(this.totalPages - 1)
+    }
   }
 
   hasPrevious(): boolean {


### PR DESCRIPTION
When on the last page and changing length (for example, deleting items) the pagination component should react accordingly and, if needed, move user to a correct page.