### PR TITLE
Fix dropdown focus issue in VoiceOver iOS

### DIFF
--- a/.changeset/nine-pears-remember.md
+++ b/.changeset/nine-pears-remember.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": patch
+---
+
+**Dropdown:** Fix focus issue with VoiceOver iOS. Fixes #1294

--- a/libs/core/src/components/popover/popover.ts
+++ b/libs/core/src/components/popover/popover.ts
@@ -239,7 +239,11 @@ export class GdsPopover extends GdsElement {
       if (this.open) {
         this._elDialog?.showModal()
         this.#focusFirstSlottedChild()
-        // Wait one event loop cycle before registering the close listener, to avoid the dialog closing immediately
+
+        // Another VoiceOver hack
+        setTimeout(() => this.#focusFirstSlottedChild(), 250)
+
+        // Wait for the next event loop cycle before registering the close listener, to avoid the dialog closing immediately
         setTimeout(
           () =>
             this._elDialog?.addEventListener('click', this.#handleClickOutside),


### PR DESCRIPTION
Fixes an issue where voiceover puts the focus on the close-button instead of the first option.

#1294