### PR TITLE
fix: 🐛 visible placeholder value then text changes and nothing selected

### DIFF
--- a/.changeset/real-cats-provide.md
+++ b/.changeset/real-cats-provide.md
@@ -1,5 +1,5 @@
 ---
-"@sebgroup/green-angular": minor
+'@sebgroup/green-angular': patch
 ---
 
-then changing dropdown texts vissible placeholder shows previous texts value if nothing is selected
+**Dropdown:** Fix previous texts value being displayed if nothing is selected and `texts` input changed

--- a/.changeset/real-cats-provide.md
+++ b/.changeset/real-cats-provide.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-angular": minor
+---
+
+then changing dropdown texts vissible placeholder shows previous texts value if nothing is selected

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -96,8 +96,8 @@ export class NggDropdownComponent implements ControlValueAccessor, OnInit {
   @Input() set texts(texts: DropdownTexts | undefined) {
     this._texts = {
       ...(texts ? texts : {}),
-      select: this.displayTextByValue(this._value),
-    }    
+      select: this.textToDisplay(texts, this._value),
+    }
   }
 
   get texts(): DropdownTexts | undefined {
@@ -250,17 +250,24 @@ export class NggDropdownComponent implements ControlValueAccessor, OnInit {
   }
 
   private displayTextByValue = (value: any) => {
+    return this.textToDisplay(this.texts, value)
+  }
+
+  private textToDisplay = (
+    dropdownTexts: DropdownTexts | undefined,
+    value: any,
+  ): string => {
     if (!Array.isArray(value))
       return (
         this.optionByValue(value)?.[this.display] ||
-        (this.texts?.placeholder ?? 'Select')
+        (dropdownTexts?.placeholder ?? 'Select')
       )
 
     const displayValues = value.map(
       (v) => this.optionByValue(v)?.[this.display],
     )
     return displayValues?.length > 2
-      ? `${displayValues.length} ${this.texts?.selected} `
-      : displayValues?.join(', ') || (this.texts?.placeholder ?? 'Select')
+      ? `${displayValues.length} ${dropdownTexts?.selected} `
+      : displayValues?.join(', ') || (dropdownTexts?.placeholder ?? 'Select')
   }
 }


### PR DESCRIPTION
if dropdown has  no selected values,  when changing text value visibleValue is calculated according to previous texts, and previous placeholder value displayed. 


To reproduce:

not select options ->change text input, -> old select placeholder displayed,  - forgot about this case in previous pr.
