### PR TITLE
Additional view options for Calendar

### DIFF
--- a/.changeset/brown-readers-cross.md
+++ b/.changeset/brown-readers-cross.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Calendar:** Add ability to customize aria-label for dates

--- a/.changeset/famous-pens-marry.md
+++ b/.changeset/famous-pens-marry.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Calendar:** Add ability to cancel focus event

--- a/.changeset/strong-ants-confess.md
+++ b/.changeset/strong-ants-confess.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Calender:** Add option to hide day name header

--- a/.changeset/wicked-files-provide.md
+++ b/.changeset/wicked-files-provide.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Calendar:** Add option to hide days outside of current month

--- a/libs/core/src/components/calendar/calendar.stories.ts
+++ b/libs/core/src/components/calendar/calendar.stories.ts
@@ -43,6 +43,17 @@ export const Basic: Story = {
   },
 }
 
+export const Minimal: Story = {
+  ...DefaultParams,
+  render: (args) => html`
+    <gds-calendar
+      label="Pick a day"
+      hideDayNames="true"
+      hideExtraneousDays="true"
+    ></gds-calendar>
+  `,
+}
+
 /**
  * This is an example of a simple inline datepicker using the calendar
  * component. It demonstrates how to control the view in the calendar,

--- a/libs/core/src/components/calendar/calendar.test.ts
+++ b/libs/core/src/components/calendar/calendar.test.ts
@@ -349,6 +349,52 @@ describe('<gds-calendar>', () => {
 
       expect(cell4).to.not.have.class('custom-date')
     })
+
+    it('should not render day names when setting hideDayNames to true', async () => {
+      const el = await fixture<GdsCalendar>(
+        html`<gds-calendar
+          .hideDayNames=${true}
+          .focusedDate=${new Date('2024-06-01')}
+        ></gds-calendar>`,
+      )
+
+      expect(el.shadowRoot?.querySelector('thead')).to.not.exist
+    })
+
+    it('should not render extraneous days when setting hideExtraneousDays to true', async () => {
+      const el = await fixture<GdsCalendar>(
+        html`<gds-calendar
+          .hideExtraneousDays=${true}
+          .focusedDate=${new Date('2024-06-01')}
+        ></gds-calendar>`,
+      )
+
+      expect(
+        el.shadowRoot?.querySelector('tbody td:first-child')?.innerHTML,
+      ).to.not.contain('27')
+    })
+
+    it('should cancel focus action when calling `event.preventDefault()` on `gds-date-focused` event', async () => {
+      const el = await fixture<GdsCalendar>(
+        html`<gds-calendar
+          .focusedDate=${new Date('2024-06-03')}
+        ></gds-calendar>`,
+      )
+
+      el.addEventListener('gds-date-focused', (e) => {
+        e.preventDefault()
+      })
+
+      el.focus()
+
+      await timeout(0)
+      await sendKeys({ press: 'ArrowDown' })
+      await timeout(0)
+
+      expect(onlyDate(el.focusedDate)).to.equal(
+        onlyDate(new Date('2024-06-03')),
+      )
+    })
   })
 
   describe('Accessibility', () => {

--- a/libs/core/src/components/calendar/calendar.test.ts
+++ b/libs/core/src/components/calendar/calendar.test.ts
@@ -395,6 +395,19 @@ describe('<gds-calendar>', () => {
         onlyDate(new Date('2024-06-03')),
       )
     })
+
+    it('should accept a custom date label template', async () => {
+      const el = await fixture<GdsCalendar>(
+        html`<gds-calendar
+          .focusedDate=${new Date('2024-06-03')}
+          .dateLabelTemplate=${(date: Date) => date.getDate().toString()}
+        ></gds-calendar>`,
+      )
+
+      expect(
+        el.shadowRoot?.querySelector('#dateCell-3')?.getAttribute('aria-label'),
+      ).to.equal('3')
+    })
   })
 
   describe('Accessibility', () => {

--- a/libs/core/src/components/calendar/calendar.ts
+++ b/libs/core/src/components/calendar/calendar.ts
@@ -140,6 +140,12 @@ export class GdsCalendar extends GdsElement {
   showWeekNumbers = false
 
   /**
+   * Whether to hide extraneous days (that fall ouside of current month)
+   */
+  @property({ type: Boolean })
+  hideExtraneousDays = false
+
+  /**
    * An array of `CustomizedDate` objects that can be used customize the appearance of dates.
    * This can only be set through the property, not through an attribute.
    */
@@ -237,43 +243,52 @@ export class GdsCalendar extends GdsElement {
                       isOutsideCurrentMonth ||
                       (this.disabledWeekends && isWeekend)
 
-                    return html`
-                      <td
-                        role="${ifDefined(isDisabled ? undefined : 'gridcell')}"
-                        class="${classMap({
-                          'custom-date': Boolean(customization),
-                          disabled: Boolean(isDisabled),
-                          today: isSameDay(currentDate, day),
-                        })}"
-                        ?disabled=${isDisabled}
-                        tabindex="${isSameDay(this.focusedDate, day) ? 0 : -1}"
-                        aria-selected="${this.value &&
-                        isSameDay(this.value, day)
-                          ? 'true'
-                          : 'false'}"
-                        aria-label="${day.toDateString()}"
-                        @click=${() =>
-                          isDisabled ? null : this.#setSelectedDate(day)}
-                        id="dateCell-${day.getDate()}"
-                      >
-                        <span
-                          class="number"
-                          style="--_color: ${displayOptions
-                            ? displayOptions?.color
-                            : ''}"
-                          >${day.getDate()}</span
-                        >
+                    const shouldRenderBlank =
+                      this.hideExtraneousDays && isOutsideCurrentMonth
 
-                        ${when(
-                          displayOptions.indicator,
-                          () =>
-                            html`<span
-                              class="indicator-${displayOptions?.indicator}"
-                              style="--_color: ${displayOptions?.color}"
-                            ></span>`,
-                        )}
-                      </td>
-                    `
+                    return shouldRenderBlank
+                      ? html`<td inert></td>`
+                      : html`
+                          <td
+                            role="${ifDefined(
+                              isDisabled ? undefined : 'gridcell',
+                            )}"
+                            class="${classMap({
+                              'custom-date': Boolean(customization),
+                              disabled: Boolean(isDisabled),
+                              today: isSameDay(currentDate, day),
+                            })}"
+                            ?disabled=${isDisabled}
+                            tabindex="${isSameDay(this.focusedDate, day)
+                              ? 0
+                              : -1}"
+                            aria-selected="${this.value &&
+                            isSameDay(this.value, day)
+                              ? 'true'
+                              : 'false'}"
+                            aria-label="${day.toDateString()}"
+                            @click=${() =>
+                              isDisabled ? null : this.#setSelectedDate(day)}
+                            id="dateCell-${day.getDate()}"
+                          >
+                            <span
+                              class="number"
+                              style="--_color: ${displayOptions
+                                ? displayOptions?.color
+                                : ''}"
+                              >${day.getDate()}</span
+                            >
+
+                            ${when(
+                              displayOptions.indicator,
+                              () =>
+                                html`<span
+                                  class="indicator-${displayOptions?.indicator}"
+                                  style="--_color: ${displayOptions?.color}"
+                                ></span>`,
+                            )}
+                          </td>
+                        `
                   })}
                 </tr>
               `,

--- a/libs/core/src/components/calendar/calendar.ts
+++ b/libs/core/src/components/calendar/calendar.ts
@@ -165,6 +165,12 @@ export class GdsCalendar extends GdsElement {
   label?: string
 
   /**
+   * A template function to customize the accessible date label.
+   */
+  @property({ attribute: false })
+  dateLabelTemplate = (date: Date) => date.toDateString()
+
+  /**
    * Returns the date cell element for the given day number.
    */
   getDateCell(dayNumber: number) {
@@ -276,7 +282,7 @@ export class GdsCalendar extends GdsElement {
                             isSameDay(this.value, day)
                               ? 'true'
                               : 'false'}"
-                            aria-label="${day.toDateString()}"
+                            aria-label="${this.dateLabelTemplate(day)}"
                             @click=${() =>
                               isDisabled ? null : this.#setSelectedDate(day)}
                             id="dateCell-${day.getDate()}"

--- a/libs/core/src/components/calendar/calendar.ts
+++ b/libs/core/src/components/calendar/calendar.ts
@@ -54,7 +54,7 @@ export type CustomizedDate = {
  * A calendar is a widget that allows the user to select a date.
  *
  * @event change - Fired when a date is selected.
- * @event gds-date-focused - Fired when focus has changed.
+ * @event gds-date-focused - Fired when focus is changed. Can be cancelled using `event.preventDefault()`.
  */
 @gdsCustomElement('gds-calendar')
 export class GdsCalendar extends GdsElement {
@@ -367,7 +367,17 @@ export class GdsCalendar extends GdsElement {
       newFocusedDate.getFullYear() >= this.min.getFullYear() &&
       newFocusedDate.getFullYear() <= this.max.getFullYear()
     ) {
-      this.focusedDate = newFocusedDate
+      const proceed = this.dispatchEvent(
+        new CustomEvent('gds-date-focused', {
+          detail: newFocusedDate,
+          bubbles: false,
+          composed: false,
+          cancelable: true,
+        }),
+      )
+      if (proceed) {
+        this.focusedDate = newFocusedDate
+      }
     }
 
     if (handled) {
@@ -376,14 +386,6 @@ export class GdsCalendar extends GdsElement {
 
       this.updateComplete.then(() => {
         this._elFocusedCell?.focus()
-
-        this.dispatchEvent(
-          new CustomEvent('gds-date-focused', {
-            detail: this.focusedDate,
-            bubbles: false,
-            composed: false,
-          }),
-        )
       })
     }
   }

--- a/libs/core/src/components/calendar/calendar.ts
+++ b/libs/core/src/components/calendar/calendar.ts
@@ -146,6 +146,12 @@ export class GdsCalendar extends GdsElement {
   hideExtraneousDays = false
 
   /**
+   * Whether to hide the day names shown above the calendar.
+   */
+  @property({ type: Boolean })
+  hideDayNames = false
+
+  /**
    * An array of `CustomizedDate` objects that can be used customize the appearance of dates.
    * This can only be set through the property, not through an attribute.
    */
@@ -184,18 +190,22 @@ export class GdsCalendar extends GdsElement {
     const currentDate = new Date()
 
     return html`<table role="grid" aria-label="${ifDefined(this.label)}">
-      <thead role="rowgroup">
-        <tr role="row">
-          ${when(this.showWeekNumbers, () => html`<th></th>`)}
-          <th>${msg('Mon')}</th>
-          <th>${msg('Tue')}</th>
-          <th>${msg('Wed')}</th>
-          <th>${msg('Thu')}</th>
-          <th>${msg('Fri')}</th>
-          <th>${msg('Sat')}</th>
-          <th>${msg('Sun')}</th>
-        </tr>
-      </thead>
+      ${when(
+        !this.hideDayNames,
+        () =>
+          html`<thead role="rowgroup">
+            <tr role="row">
+              ${when(this.showWeekNumbers, () => html`<th></th>`)}
+              <th>${msg('Mon')}</th>
+              <th>${msg('Tue')}</th>
+              <th>${msg('Wed')}</th>
+              <th>${msg('Thu')}</th>
+              <th>${msg('Fri')}</th>
+              <th>${msg('Sat')}</th>
+              <th>${msg('Sun')}</th>
+            </tr>
+          </thead>`,
+      )}
       <tbody role="rowgroup">
         ${renderMonthGridView(
           this.focusedDate,


### PR DESCRIPTION
This PR adds the following features to `<gds-calendar>`:
- Option to hide day name header
- Option to hide days outside of displayed month
- Option to cancel `gds-date-focused` event
- Ability to customize `aria-label` for dates through a template function