### PR TITLE
Move tokens to Theme

### DIFF
--- a/libs/core/.storybook/preview.ts
+++ b/libs/core/.storybook/preview.ts
@@ -32,7 +32,10 @@ export default {
   parameters: {
     docs: {
       page: DocTemplate,
-      transformSource: (source: any) => {
+      transformSource: (source: any, context: any) => {
+        if (context.parameters?.globals?.disableTheme) {
+          return source
+        }
         const regexRes = source.match(/<gds-theme>([\s\S]*?)<\/gds-theme>/)
         return regexRes ? regexRes[1] : source
       },
@@ -53,12 +56,12 @@ export default {
   },
   decorators: [
     (storyFn: any, context: any) => {
-      // Initialize previousStyle if it doesn't exist
       if (typeof context.globals.previousStyle === 'undefined') {
         context.globals.previousStyle = '2023' // Default to 2023
       }
 
       const style = context.globals.style || '2023'
+      const disableTheme = context.parameters?.globals?.disableTheme
 
       if (style === '2016') {
         if (context.globals.previousStyle !== '2016') {
@@ -72,7 +75,11 @@ export default {
 
       context.globals.previousStyle = style
 
-      return html`<gds-theme>${storyFn()}</gds-theme>`
+      if (disableTheme) {
+        return storyFn()
+      } else {
+        return html`<gds-theme>${storyFn()}</gds-theme>`
+      }
     },
   ],
 }

--- a/libs/core/src/components/button/button.ts
+++ b/libs/core/src/components/button/button.ts
@@ -9,7 +9,6 @@ import { forwardAttributes } from '../../utils/directives'
 import { TransitionalStyles } from '../../transitional-styles'
 import '../../primitives/ripple'
 
-import { tokens } from '../../tokens.style'
 import style from './button.style.css?inline'
 
 import { gdsCustomElement, html as customElementHtml } from '../../scoping'

--- a/libs/core/src/components/button/button.ts
+++ b/libs/core/src/components/button/button.ts
@@ -33,7 +33,8 @@ const html = stripWhitespace(customElementHtml)
  */
 @gdsCustomElement('gds-button')
 export class GdsButton<ValueT = any> extends GdsFormControlElement<ValueT> {
-  static styles = [tokens, unsafeCSS(style)]
+  // static styles = [tokens, unsafeCSS(style)]
+  static styles = [unsafeCSS(style)]
 
   /**
    * @internal

--- a/libs/core/src/components/calendar/calendar.ts
+++ b/libs/core/src/components/calendar/calendar.ts
@@ -21,7 +21,6 @@ import { renderMonthGridView } from './functions'
 import { watch } from '../../utils/decorators/watch'
 
 import style from './calendar.styles'
-// import { tokens } from '../../tokens.style'
 /**
  * Used to customize the appearance of a date in the calendar.
  */

--- a/libs/core/src/components/calendar/calendar.ts
+++ b/libs/core/src/components/calendar/calendar.ts
@@ -21,7 +21,7 @@ import { renderMonthGridView } from './functions'
 import { watch } from '../../utils/decorators/watch'
 
 import style from './calendar.styles'
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 /**
  * Used to customize the appearance of a date in the calendar.
  */
@@ -58,7 +58,7 @@ export type CustomizedDate = {
  */
 @gdsCustomElement('gds-calendar')
 export class GdsCalendar extends GdsElement {
-  static styles = [tokens, style]
+  static styles = [style]
   static shadowRootOptions: ShadowRootInit = {
     mode: 'open',
     delegatesFocus: true,

--- a/libs/core/src/components/content/divider/divider.ts
+++ b/libs/core/src/components/content/divider/divider.ts
@@ -4,7 +4,7 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import DividerCSS from './divider.style.css'
@@ -19,7 +19,7 @@ import DividerCSS from './divider.style.css'
  */
 @gdsCustomElement('gds-divider')
 export class GdsDivider extends GdsElement {
-  static styles = [tokens, DividerCSS]
+  static styles = [DividerCSS]
 
   /**
    * Controls the color property of the divider.

--- a/libs/core/src/components/content/divider/divider.ts
+++ b/libs/core/src/components/content/divider/divider.ts
@@ -4,7 +4,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import DividerCSS from './divider.style.css'

--- a/libs/core/src/components/content/spacer/spacer.ts
+++ b/libs/core/src/components/content/spacer/spacer.ts
@@ -3,12 +3,12 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 @gdsCustomElement('gds-spacer')
 export class GdsSpacer extends GdsElement {
-  static styles = [tokens]
+  // static styles = [tokens]
 
   /**
    * Controls the size property of the spacer.

--- a/libs/core/src/components/content/spacer/spacer.ts
+++ b/libs/core/src/components/content/spacer/spacer.ts
@@ -3,7 +3,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 @gdsCustomElement('gds-spacer')

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -5,7 +5,7 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import TextCSS from './text.style.css'
@@ -20,9 +20,7 @@ import TextCSS from './text.style.css'
  */
 @gdsCustomElement('gds-text')
 export class GdsText extends GdsElement {
-  // static styles = [tokens, TextCSS, ]
-
-  static styles = [tokens, TextCSS]
+  static styles = [TextCSS]
 
   /**
    * Controls the tag of the text.

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -5,7 +5,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import TextCSS from './text.style.css'

--- a/libs/core/src/components/datepicker/datepicker.ts
+++ b/libs/core/src/components/datepicker/datepicker.ts
@@ -35,7 +35,6 @@ import '../../components/icon/icons/calendar'
 import '../../components/icon/icons/chevron-left'
 import '../../components/icon/icons/chevron-right'
 
-// import { tokens } from '../../tokens.style'
 import { styles } from './datepicker.styles'
 
 type DatePart = 'year' | 'month' | 'day'

--- a/libs/core/src/components/datepicker/datepicker.ts
+++ b/libs/core/src/components/datepicker/datepicker.ts
@@ -35,7 +35,7 @@ import '../../components/icon/icons/calendar'
 import '../../components/icon/icons/chevron-left'
 import '../../components/icon/icons/chevron-right'
 
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 import { styles } from './datepicker.styles'
 
 type DatePart = 'year' | 'month' | 'day'
@@ -59,7 +59,7 @@ type DateFormatLayout = {
  */
 @gdsCustomElement('gds-datepicker')
 export class GdsDatepicker extends GdsFormControlElement<Date> {
-  static styles = [tokens, styles]
+  static styles = [styles]
   static shadowRootOptions: ShadowRootInit = {
     mode: 'open',
     delegatesFocus: true,

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -29,7 +29,7 @@ import '../button'
 
 import { GdsFormControlElement } from '../form/form-control'
 
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 import styles from './dropdown.styles'
 import { TransitionalStyles } from '../../transitional-styles'
 
@@ -52,7 +52,7 @@ export class GdsDropdown<ValueT = any>
   extends GdsFormControlElement<ValueT | ValueT[]>
   implements OptionsContainer
 {
-  static styles = [tokens, styles]
+  static styles = [styles]
   static shadowRootOptions: ShadowRootInit = {
     mode: 'open',
     delegatesFocus: true,

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -29,7 +29,6 @@ import '../button'
 
 import { GdsFormControlElement } from '../form/form-control'
 
-// import { tokens } from '../../tokens.style'
 import styles from './dropdown.styles'
 import { TransitionalStyles } from '../../transitional-styles'
 

--- a/libs/core/src/components/input/input.ts_.txt
+++ b/libs/core/src/components/input/input.ts_.txt
@@ -14,7 +14,6 @@ import {
   gdsCustomElement,
   html,
 } from '../../utils/helpers/custom-element-scoping'
-import { tokens } from '../../tokens.style'
 
 import styles from './input.styles.css'
 

--- a/libs/core/src/components/layout/card/card.ts
+++ b/libs/core/src/components/layout/card/card.ts
@@ -2,7 +2,7 @@ import {
   gdsCustomElement,
   html,
 } from '../../../utils/helpers/custom-element-scoping'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 import { GdsContainer } from '../container'
 import CardCSS from './card.style.css'
@@ -20,7 +20,7 @@ import CardCSS from './card.style.css'
  */
 @gdsCustomElement('gds-card')
 export class GdsCard extends GdsContainer {
-  static styles = [tokens, CardCSS]
+  static styles = [CardCSS]
 
   /**
    * Controls the box-shadow property of the card.

--- a/libs/core/src/components/layout/card/card.ts
+++ b/libs/core/src/components/layout/card/card.ts
@@ -2,7 +2,6 @@ import {
   gdsCustomElement,
   html,
 } from '../../../utils/helpers/custom-element-scoping'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 import { GdsContainer } from '../container'
 import CardCSS from './card.style.css'

--- a/libs/core/src/components/layout/container/container.ts
+++ b/libs/core/src/components/layout/container/container.ts
@@ -3,7 +3,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import ContainerCSS from './container.style.css'

--- a/libs/core/src/components/layout/container/container.ts
+++ b/libs/core/src/components/layout/container/container.ts
@@ -3,7 +3,7 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import ContainerCSS from './container.style.css'
@@ -21,7 +21,7 @@ import ContainerCSS from './container.style.css'
 
 @gdsCustomElement('gds-container')
 export class GdsContainer extends GdsElement {
-  static styles = [tokens, ContainerCSS]
+  static styles = [ContainerCSS]
 
   /**
    * Controls the display property of the container.

--- a/libs/core/src/components/layout/flex/flex.ts
+++ b/libs/core/src/components/layout/flex/flex.ts
@@ -2,7 +2,6 @@ import {
   gdsCustomElement,
   html,
 } from '../../../utils/helpers/custom-element-scoping'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import FlexCSS from './flex.style.css'

--- a/libs/core/src/components/layout/flex/flex.ts
+++ b/libs/core/src/components/layout/flex/flex.ts
@@ -2,7 +2,7 @@ import {
   gdsCustomElement,
   html,
 } from '../../../utils/helpers/custom-element-scoping'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import FlexCSS from './flex.style.css'
@@ -20,7 +20,7 @@ import { GdsContainer } from '../container'
 
 @gdsCustomElement('gds-flex')
 export class GdsFlex extends GdsContainer {
-  static styles = [tokens, FlexCSS]
+  static styles = [FlexCSS]
 
   /**
    * Controls the gap property of the flex.

--- a/libs/core/src/components/layout/grid/grid.ts
+++ b/libs/core/src/components/layout/grid/grid.ts
@@ -3,7 +3,7 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import GridCSS from './grid.style.css'
@@ -17,7 +17,7 @@ import GridCSS from './grid.style.css'
  */
 @gdsCustomElement('gds-grid')
 export class GdsGrid extends GdsElement {
-  static styles = [tokens, GridCSS]
+  static styles = [GridCSS]
 
   /**
    * The number of columns for the grid. This can be a single value that applies to all breakpoints, or a string of three space-separated tokens in the format "l:desktop m:tablet s:mobile", each token specifying the number of columns for that device type respectively.

--- a/libs/core/src/components/layout/grid/grid.ts
+++ b/libs/core/src/components/layout/grid/grid.ts
@@ -3,7 +3,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import GridCSS from './grid.style.css'

--- a/libs/core/src/components/media/img/img.ts
+++ b/libs/core/src/components/media/img/img.ts
@@ -4,7 +4,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import IMGCSS from './img.style.css'

--- a/libs/core/src/components/media/img/img.ts
+++ b/libs/core/src/components/media/img/img.ts
@@ -4,7 +4,7 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import IMGCSS from './img.style.css'
@@ -21,7 +21,7 @@ import IMGCSS from './img.style.css'
  */
 @gdsCustomElement('gds-img')
 export class GdsImg extends GdsElement {
-  static styles = [tokens, IMGCSS]
+  static styles = [IMGCSS]
 
   /**
    * Controls the aspect ratio of the image.

--- a/libs/core/src/components/media/video/video.ts
+++ b/libs/core/src/components/media/video/video.ts
@@ -4,7 +4,7 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-import { tokens } from '../../../tokens.style'
+// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import VideoCSS from './video.style.css'
@@ -19,7 +19,7 @@ import VideoCSS from './video.style.css'
  */
 @gdsCustomElement('gds-video')
 export class GdsVideo extends GdsElement {
-  static styles = [tokens, VideoCSS]
+  static styles = [VideoCSS]
 
   /**
    * Controls the aspect ratio of the image.

--- a/libs/core/src/components/media/video/video.ts
+++ b/libs/core/src/components/media/video/video.ts
@@ -4,7 +4,6 @@ import {
   html,
 } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
-// import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 import VideoCSS from './video.style.css'

--- a/libs/core/src/components/menu-button/menu-button.ts
+++ b/libs/core/src/components/menu-button/menu-button.ts
@@ -6,7 +6,6 @@ import { literal, html as staticHtml } from 'lit/static-html.js'
 import { GdsElement } from '../../gds-element'
 import { gdsCustomElement } from '../../scoping'
 import { constrainSlots } from '../../utils/helpers'
-// import { tokens } from '../../tokens.style'
 
 import style from './menu-button.css?inline'
 

--- a/libs/core/src/components/menu-button/menu-button.ts
+++ b/libs/core/src/components/menu-button/menu-button.ts
@@ -6,7 +6,7 @@ import { literal, html as staticHtml } from 'lit/static-html.js'
 import { GdsElement } from '../../gds-element'
 import { gdsCustomElement } from '../../scoping'
 import { constrainSlots } from '../../utils/helpers'
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 
 import style from './menu-button.css?inline'
 
@@ -22,7 +22,7 @@ import style from './menu-button.css?inline'
  */
 @gdsCustomElement('gds-menu-button')
 export class MenuButton extends GdsElement {
-  static styles = [tokens, unsafeCSS(style)]
+  static styles = [unsafeCSS(style)]
 
   static shadowRootOptions: ShadowRootInit = {
     mode: 'open',

--- a/libs/core/src/components/segmented-control/segment/segment.ts
+++ b/libs/core/src/components/segmented-control/segment/segment.ts
@@ -4,7 +4,6 @@ import { gdsCustomElement, html } from '../../../scoping'
 import { TransitionalStyles } from '../../../transitional-styles'
 import { unsafeCSS } from 'lit'
 
-import { tokens } from '../../../tokens.style'
 import style from './segment.style.css?inline'
 
 /**
@@ -12,7 +11,7 @@ import style from './segment.style.css?inline'
  */
 @gdsCustomElement('gds-segment')
 export class GdsSegment<ValueT = any> extends GdsElement {
-  static styles = [...tokens, unsafeCSS(style)]
+  static styles = [unsafeCSS(style)]
 
   /**
    * Whether the segment is selected

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -12,7 +12,7 @@ import { GdsSegment } from '../../components/segmented-control/segment'
 import '../../components/icon/icons/chevron-left'
 import '../../components/icon/icons/chevron-right'
 
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 import style from './segmented-control.style.css?inline'
 
 const BTN_SIZE = {
@@ -34,7 +34,7 @@ const getSegmentGap = (transitionalStyles: boolean) =>
  */
 @gdsCustomElement('gds-segmented-control')
 export class GdsSegmentedControl<ValueT = any> extends GdsElement {
-  static styles = [tokens, unsafeCSS(style)]
+  static styles = [unsafeCSS(style)]
 
   /**
    * Minimum width of each segment. Used for calculating the number of visible

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -12,7 +12,6 @@ import { GdsSegment } from '../../components/segmented-control/segment'
 import '../../components/icon/icons/chevron-left'
 import '../../components/icon/icons/chevron-right'
 
-// import { tokens } from '../../tokens.style'
 import style from './segmented-control.style.css?inline'
 
 const BTN_SIZE = {

--- a/libs/core/src/components/theme/theme.stories.ts
+++ b/libs/core/src/components/theme/theme.stories.ts
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/web-components'
+
+import { html } from 'lit'
+
+/**
+ * The `gds-theme` is a custom element that provides tokens and high level styling that lives system wide.
+ *
+ * It is mandatory and all component should be wrapped in a `gds-theme` element.
+ *
+ * @status beta
+ *
+ */
+
+const meta: Meta = {
+  title: 'Docs/Theme',
+  component: 'gds-theme',
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+const DefaultParams: Story = {
+  parameters: {
+    docs: {
+      source: { format: true, type: 'dynamic' },
+    },
+    controls: { disable: true },
+  },
+}
+
+/**
+ * Card
+ */
+
+export const Theme: Story = {
+  ...DefaultParams,
+  render: (args) => html` <gds-theme> Theme example </gds-theme> `,
+}

--- a/libs/core/src/components/theme/theme.stories.ts
+++ b/libs/core/src/components/theme/theme.stories.ts
@@ -3,11 +3,48 @@ import type { Meta, StoryObj } from '@storybook/web-components'
 import { html } from 'lit'
 
 /**
- * The `gds-theme` is a custom element that provides tokens and high level styling that lives system wide.
  *
- * It is mandatory and all component should be wrapped in a `gds-theme` element.
+ *
+ * The `gds-theme` is a custom element that provides CSS variables for a part of the DOM tree.
+ * Every descendant of this component will inherit the CSS variables provided by the theme set on this component.
+ * It is mandatory and all components should be wrapped in a `gds-theme` element to ensure consistent styling.
  *
  * @status beta
+ *
+ * ## Usage
+ *
+ * ```html
+ * <gds-theme color-scheme="dark">
+ *   <!-- Your content here will inherit the dark theme -->
+ * </gds-theme>
+ * ```
+ *
+ * ## Properties
+ *
+ * - `colorScheme`: This property reflects the theme mode and can be set to `light`, `dark`, or `auto`.
+ *   - `light`: Applies the light theme.
+ *   - `dark`: Applies the dark theme.
+ *   - `auto`: Automatically switches between light and dark themes based on the user's system preferences.
+ *
+ * ## Methods
+ *
+ * - `connectedCallback()`: This lifecycle method is called when the element is added to the document.
+ *   It applies transitional styles to the component.
+ *
+ * ## Styles
+ *
+ * The component uses the following styles:
+ * - `tokens`: A set of CSS variables and design tokens.
+ * - `style`: Component-specific styles defined in `theme.style.css`.
+ *
+ * ## Example
+ *
+ * ```html
+ * <gds-theme color-scheme="auto">
+ *   <div>Your themed content here</div>
+ * </gds-theme>
+ * ```
+ *
  *
  */
 
@@ -30,10 +67,9 @@ const DefaultParams: Story = {
 }
 
 /**
- * Card
+ * Theme
  */
 
 export const Theme: Story = {
   ...DefaultParams,
-  render: (args) => html` <gds-theme> Theme example </gds-theme> `,
 }

--- a/libs/core/src/components/theme/theme.stories.ts
+++ b/libs/core/src/components/theme/theme.stories.ts
@@ -1,5 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/web-components'
-
+import '../media/img'
+import '../media/video'
+import '../layout/card'
+import '../layout/container'
+import '../layout/flex'
+import '../content/text'
+import '../content/divider'
+import '../icon/icons/arrow-down.js'
+import '../icon/icons/arrow-right.js'
+import '../icon/icons/circles-three.js'
 import { html } from 'lit'
 
 /**
@@ -63,6 +72,9 @@ const DefaultParams: Story = {
       source: { format: true, type: 'dynamic' },
     },
     controls: { disable: true },
+    globals: {
+      disableTheme: true,
+    },
   },
 }
 
@@ -72,4 +84,122 @@ const DefaultParams: Story = {
 
 export const Theme: Story = {
   ...DefaultParams,
+  parameters: {
+    ...DefaultParams.parameters,
+    globals: {
+      disableTheme: true,
+    },
+  },
+  render: () => html`
+    <gds-theme>
+      <gds-grid columns="xs{1} m{3} l{3}" gap="l">
+        <gds-card shadow="s{xs} m{xs} l{s}" radius="xs" overflow="hidden">
+          <gds-flex display="flex" gap="0" direction="column" align="stretch">
+            <gds-container position="relative">
+              <gds-img
+                src="https://github.com/seb-oss/green/assets/2398447/cd458a77-13f1-495c-960c-ce23a18e5d9f"
+                ratio="1/1"
+              ></gds-img>
+              <gds-container position="absolute" inset="20px 20px auto auto">
+                <gds-button>
+                  <gds-icon-arrow-down></gds-icon-arrow-down>
+                </gds-button>
+              </gds-container>
+            </gds-container>
+            <gds-flex
+              direction="column"
+              padding="s{xs} m{l} l{l}"
+              align="flex-start"
+              gap="l"
+            >
+              <gds-flex gap="s" direction="column">
+                <gds-text tag="h2" size="title-large">James Doe</gds-text>
+                <gds-text>
+                  Passionate software engineer with a love for coding and
+                  problem-solving.
+                </gds-text>
+              </gds-flex>
+              <gds-divider opacity="0.2"></gds-divider>
+              <gds-button>
+                Follow
+                <gds-icon-circles-three slot="lead"></gds-icon-circles-three>
+              </gds-button>
+            </gds-flex>
+          </gds-flex>
+        </gds-card>
+        <gds-card shadow="l" radius="m" border="3xs/base300" overflow="hidden">
+          <gds-flex gap="m" direction="column" padding="s">
+            <gds-container position="relative">
+              <gds-img
+                src="https://github.com/seb-oss/green/assets/2398447/dff488cc-700e-47f9-b7f7-3788eb742c11"
+                ratio="1/1"
+                radius="xs"
+              ></gds-img>
+              <gds-container position="absolute" inset="20px 20px auto auto">
+                <gds-button>
+                  <gds-icon-arrow-down></gds-icon-arrow-down>
+                </gds-button>
+              </gds-container>
+            </gds-container>
+            <gds-flex
+              direction="column"
+              padding="s{xs} m{s} l{s}"
+              align="flex-start"
+              gap="l"
+            >
+              <gds-flex gap="s" direction="column">
+                <gds-text tag="h2" size="title-large">Lorem Ipsum</gds-text>
+                <gds-text>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                  do eiusmod tempor incididunt.
+                </gds-text>
+              </gds-flex>
+              <gds-button>
+                Button
+                <gds-icon-arrow-right slot="trail"></gds-icon-arrow-right>
+              </gds-button>
+            </gds-flex>
+          </gds-flex>
+        </gds-card>
+        <gds-card radius="m" overflow="hidden">
+          <gds-flex position="relative" height="100%">
+            <gds-video
+              src="https://github.com/seb-oss/green/assets/2398447/d77a95d0-e4d7-4c49-bd95-50d0f72f1a7a"
+              fit="cover"
+              ratio="1/1"
+              events="none"
+              autoplay
+              muted
+              loop
+            ></gds-video>
+            <gds-card
+              position="absolute"
+              inset="50% 0px 0px 0px"
+              filter="0"
+              background="base900/0.6"
+              color="white-text"
+              mask="top"
+            >
+              <gds-flex
+                direction="column"
+                justify="flex-end"
+                padding="4xl 2xl 2xl 2xl"
+                gap="l"
+                height="100%"
+              >
+                <gds-container>
+                  <gds-text size="title-large">Jane Doe</gds-text>
+                  <gds-text size="body-medium">UX Designer</gds-text>
+                </gds-container>
+                <gds-flex gap="s">
+                  <gds-button rank="secondary">Message</gds-button>
+                  <gds-button rank="secondary">Follow</gds-button>
+                </gds-flex>
+              </gds-flex>
+            </gds-card>
+          </gds-flex>
+        </gds-card>
+      </gds-grid>
+    </gds-theme>
+  `,
 }

--- a/libs/core/src/components/theme/theme.style.css.ts
+++ b/libs/core/src/components/theme/theme.style.css.ts
@@ -1,0 +1,8 @@
+import { css } from 'lit'
+
+const style = css`
+  :host {
+    display: contents;
+  }
+`
+export default style

--- a/libs/core/src/components/theme/theme.ts
+++ b/libs/core/src/components/theme/theme.ts
@@ -2,7 +2,10 @@ import { property } from 'lit/decorators.js'
 import { GdsElement } from '../../gds-element'
 import { gdsCustomElement, html } from '../../scoping'
 import { TransitionalStyles } from '../../transitional-styles'
-import { css } from 'lit'
+
+// Tokens and styles
+import { tokens } from '../../tokens.style'
+import style from './theme.style.css'
 
 /**
  * @element gds-theme
@@ -17,11 +20,7 @@ import { css } from 'lit'
  */
 @gdsCustomElement('gds-theme')
 export class GdsTheme extends GdsElement {
-  static styles = css`
-    :host {
-      display: contents;
-    }
-  `
+  static styles = [tokens, style]
   /**
    * The theme mode. Can be `light`, `dark`, or `auto`.
    */

--- a/libs/core/src/primitives/listbox/option.ts
+++ b/libs/core/src/primitives/listbox/option.ts
@@ -11,7 +11,6 @@ import style from './option.styles'
 
 import { watch } from '../../utils/decorators'
 import { Focusable } from '../../mixins/focusable'
-// import { tokens } from '../../tokens.style'
 
 export interface OptionsContainer extends HTMLElement {
   options: GdsOption[]

--- a/libs/core/src/primitives/listbox/option.ts
+++ b/libs/core/src/primitives/listbox/option.ts
@@ -11,7 +11,7 @@ import style from './option.styles'
 
 import { watch } from '../../utils/decorators'
 import { Focusable } from '../../mixins/focusable'
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 
 export interface OptionsContainer extends HTMLElement {
   options: GdsOption[]
@@ -35,7 +35,7 @@ export interface OptionsContainer extends HTMLElement {
  */
 @gdsCustomElement('gds-option')
 export class GdsOption extends Focusable(GdsElement) {
-  static styles = [tokens, style]
+  static styles = [style]
 
   /**
    * The value of the option.

--- a/libs/core/src/primitives/ripple/ripple.ts
+++ b/libs/core/src/primitives/ripple/ripple.ts
@@ -2,11 +2,11 @@ import { LitElement, html, unsafeCSS } from 'lit'
 import { query } from 'lit/decorators.js'
 import { gdsCustomElement } from '../../scoping'
 import styles from './ripple.styles.scss?inline'
-import { tokens } from '../../tokens.style'
+// import { tokens } from '../../tokens.style'
 
 @gdsCustomElement('gds-ripple')
 export class Ripple extends LitElement {
-  static styles = [tokens, unsafeCSS(styles)]
+  static styles = [unsafeCSS(styles)]
 
   @query('div') private _rippleEl?: HTMLDivElement
 

--- a/libs/core/src/primitives/ripple/ripple.ts
+++ b/libs/core/src/primitives/ripple/ripple.ts
@@ -2,7 +2,6 @@ import { LitElement, html, unsafeCSS } from 'lit'
 import { query } from 'lit/decorators.js'
 import { gdsCustomElement } from '../../scoping'
 import styles from './ripple.styles.scss?inline'
-// import { tokens } from '../../tokens.style'
 
 @gdsCustomElement('gds-ripple')
 export class Ripple extends LitElement {

--- a/libs/core/src/storybook-docs/style/spacing.mdx
+++ b/libs/core/src/storybook-docs/style/spacing.mdx
@@ -3,6 +3,7 @@ import '../../components/layout/container/container'
 import '../../components/layout/card/card'
 import '../../components/layout/flex/flex'
 import '../../components/content/text/text'
+import '../../components/theme'
 
 <Meta title="Docs/Style/Size" />
 
@@ -13,105 +14,106 @@ import '../../components/content/text/text'
 The spacing scale is used for margin, padding, gap, radius and all the spacing values.
 
 ### Spacing Scale
-<gds-flex direction="column" gap="s">
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center" overflow="hidden">
-            <gds-text min="10" align="left">MAX*</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 max 0 0" background="base900" mask="right"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">8XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 8xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">7XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 7xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">6XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 6xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">5XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 5xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">4XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 4xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">3XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 3xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">2XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 2xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">XL</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 xl 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">L</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 l 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">M</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 m 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">S</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 s 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">XS</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 xs 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">2XS</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 2xs 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-    <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">3XS</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 3xs 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
+<gds-theme>
+    <gds-flex direction="column" gap="s">
         <gds-card shadow="s" radius="s">
-        <gds-flex gap="s" padding="s l" align="center">
-            <gds-text min="10" align="left">0</gds-text>
-            <gds-card radius="xs" width="1px" height="40px" padding="0 0 0 0" background="base900"></gds-card>
-        </gds-flex>
-    </gds-card>
-</gds-flex>
- 
+            <gds-flex gap="s" padding="s l" align="center" overflow="hidden">
+                <gds-text min="10" align="left">MAX*</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 max 0 0" background="base900" mask="right"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">8XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 8xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">7XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 7xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">6XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 6xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">5XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 5xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">4XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 4xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">3XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 3xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">2XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 2xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">XL</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 xl 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">L</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 l 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">M</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 m 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">S</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 s 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">XS</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 xs 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">2XS</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 2xs 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+        <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">3XS</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 3xs 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+            <gds-card shadow="s" radius="s">
+            <gds-flex gap="s" padding="s l" align="center">
+                <gds-text min="10" align="left">0</gds-text>
+                <gds-card radius="xs" width="1px" height="40px" padding="0 0 0 0" background="base900"></gds-card>
+            </gds-flex>
+        </gds-card>
+    </gds-flex>
+</gds-theme>
 
  <br />
  <br />
@@ -129,8 +131,10 @@ The spacing scale is used for margin, padding, gap, radius and all the spacing v
  <br />
  <br />
 
-<gds-card background="base900" color="white-text" radius="max" width="200px">
-    <gds-flex align="center" justify="center"  height="200px">
-        <gds-text tag="h5">MAX (999px)</gds-text>
-    </gds-flex>
-</gds-card>
+<gds-theme>
+    <gds-card background="base900" color="white-text" radius="max" width="200px">
+        <gds-flex align="center" justify="center"  height="200px">
+            <gds-text tag="h5">MAX (999px)</gds-text>
+        </gds-flex>
+    </gds-card>
+</gds-theme>

--- a/libs/core/src/storybook-docs/style/typography.mdx
+++ b/libs/core/src/storybook-docs/style/typography.mdx
@@ -10,101 +10,111 @@ import '../../components/content/text/text'
 The scale is based on the place of the text in the hierarchy.
 
 ## Body
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0"  >
-        <gds-text min="30" align="left">`body-small`</gds-text>
-        <gds-text size="body-small">body-small</gds-text>
+<gds-theme>
+    <gds-flex display="flex" direction="column">
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0"  >
+            <gds-text min="30" align="left">`body-small`</gds-text>
+            <gds-text size="body-small">body-small</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`body-medium`</gds-text>
+            <gds-text size="body-medium">body-medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`body-large`</gds-text>
+            <gds-text size="body-large">body-large</gds-text>
+        </gds-flex>
     </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`body-medium`</gds-text>
-        <gds-text size="body-medium">body-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`body-large`</gds-text>
-        <gds-text size="body-large">body-large</gds-text>
-    </gds-flex>
-</gds-flex>
+</gds-theme>
  
 ## Display
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`display-small`</gds-text>
-        <gds-text size="display-small">display-small</gds-text>
+<gds-theme>
+    <gds-flex display="flex" direction="column">
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`display-small`</gds-text>
+            <gds-text size="display-small">display-small</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`display-medium`</gds-text>
+            <gds-text size="display-medium">display-medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`display-large`</gds-text>
+            <gds-text size="display-large">display-large</gds-text>
+        </gds-flex>
     </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`display-medium`</gds-text>
-        <gds-text size="display-medium">display-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`display-large`</gds-text>
-        <gds-text size="display-large">display-large</gds-text>
-    </gds-flex>
-</gds-flex>
+</gds-theme>
 
 ## Headline
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`headline-small`</gds-text>
-        <gds-text size="headline-small">headline-small</gds-text>
+<gds-theme>
+    <gds-flex display="flex" direction="column">
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`headline-small`</gds-text>
+            <gds-text size="headline-small">headline-small</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`headline-medium`</gds-text>
+            <gds-text size="headline-medium">headline-medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`headline-large`</gds-text>
+            <gds-text size="headline-large">headline-large</gds-text>
+        </gds-flex>
     </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`headline-medium`</gds-text>
-        <gds-text size="headline-medium">headline-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`headline-large`</gds-text>
-        <gds-text size="headline-large">headline-large</gds-text>
-    </gds-flex>
-</gds-flex>
+</gds-theme>
 
 ## Title
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`title-small`</gds-text>
-        <gds-text size="title-small">title-small</gds-text>
+<gds-theme>
+    <gds-flex display="flex" direction="column">
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`title-small`</gds-text>
+            <gds-text size="title-small">title-small</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`title-medium`</gds-text>
+            <gds-text size="title-medium">title-medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`title-large`</gds-text>
+            <gds-text size="title-large">title-large</gds-text>
+        </gds-flex>
     </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`title-medium`</gds-text>
-        <gds-text size="title-medium">title-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`title-large`</gds-text>
-        <gds-text size="title-large">title-large</gds-text>
-    </gds-flex>
-</gds-flex>
+</gds-theme>
 
 ## Label
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-overline`</gds-text>
-        <gds-text size="label-overline">Label Overline</gds-text>
+<gds-theme>
+    <gds-flex display="flex" direction="column">
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-overline`</gds-text>
+            <gds-text size="label-overline">Label Overline</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-input-medium`</gds-text>
+            <gds-text size="label-input-medium">Label Input Medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-input-large`</gds-text>
+            <gds-text size="label-input-large">label-input-large</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-information-medium`</gds-text>
+            <gds-text size="label-information-medium">label-information-medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-information-large`</gds-text>
+            <gds-text size="label-information-large">label-information-large</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-small`</gds-text>
+            <gds-text size="label-small">label-small</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-medium`</gds-text>
+            <gds-text size="label-medium">label-medium</gds-text>
+        </gds-flex>
+        <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+            <gds-text min="30" align="left">`label-large`</gds-text>
+            <gds-text size="label-large">label-large</gds-text>
+        </gds-flex>
     </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-input-medium`</gds-text>
-        <gds-text size="label-input-medium">Label Input Medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-input-large`</gds-text>
-        <gds-text size="label-input-large">label-input-large</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-information-medium`</gds-text>
-        <gds-text size="label-information-medium">label-information-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-information-large`</gds-text>
-        <gds-text size="label-information-large">label-information-large</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-small`</gds-text>
-        <gds-text size="label-small">label-small</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-medium`</gds-text>
-        <gds-text size="label-medium">label-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-large`</gds-text>
-        <gds-text size="label-large">label-large</gds-text>
-    </gds-flex>
-</gds-flex>
+</gds-theme>


### PR DESCRIPTION
This PR moves tokens from individual components to the Theme component. 
It is intended to be merged and used first on the #1507 PR

Also should we move other things to Theme for example fonts ?
 
This change affects the following components: 

1. Button
2. Calendar
3. Divider
4. Spacer
5. Text
6. Datepicker
7. Dropdown
8. Card
9. Container
10. Flex
11. Grid
12. IMG
13. Video
14. Menu Button
15. Segmented Control 
16. Primitive Listbox 
17. Primitive Ripple


Let me know if you see a problem with this change or if there should be done more checks. 