### PR TITLE
Update coachmarks

### DIFF
--- a/.changeset/dull-buses-shake.md
+++ b/.changeset/dull-buses-shake.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Coachmarks:** Add `computeVisibility` callback for customizing visibility

--- a/.changeset/many-hats-guess.md
+++ b/.changeset/many-hats-guess.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": patch
+---
+
+**Coachmark:** Remove hard coded dependence on `main` element

--- a/.changeset/stupid-squids-type.md
+++ b/.changeset/stupid-squids-type.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Coachmark:** Rename close event to `gds-ui-state` to align with other components

--- a/libs/core/src/components/coachmark/coachmark.stories.ts
+++ b/libs/core/src/components/coachmark/coachmark.stories.ts
@@ -38,19 +38,28 @@ const DefaultParams: Story = {
   },
 }
 
+/**
+ * Because this is the default story that also renders at the top of the page, the
+ * coachmark will be shown in the first panel only, since the `#targetElement` selector
+ * will match the first element in the DOM.
+ */
 export const Basic: Story = {
   ...DefaultParams,
   render: () => html`
-    <main>
-      ${document.querySelector('gds-coachmark')
-        ? html`The coachmark is already visible in another panel`
-        : html` <p id="targetElement">Clicking will close the coachmark</p>
-            <gds-coachmark placement="top" .target=${['#targetElement']}>
-              <div class="gds-coachmark" aria-modal="false">
-                <div>This is the coachmark content.</div>
-              </div>
-              <div id="gds-arrow"></div>
-            </gds-coachmark>`}
-    </main>
+    <div style="height: 200px">
+      <p>
+        The coachmark will target the first element that matches the selector.
+        Clicking anywhere closes the coachmark.
+      </p>
+      <p
+        id="targetElement"
+        style="width: 200px; background: #ddd; padding: 1px"
+      >
+        Coachmark target element
+      </p>
+      <gds-coachmark .target=${['#targetElement']} placement="bottom">
+        This is the coachmark content.
+      </gds-coachmark>
+    </div>
   `,
 }

--- a/libs/core/src/components/coachmark/coachmark.stories.ts
+++ b/libs/core/src/components/coachmark/coachmark.stories.ts
@@ -8,9 +8,9 @@ import './index.ts'
  * Coachmarks are contextual tips that focus on making the user
  * aware of a new feature, the benefits of an existing one or a moved feature within an interface.
  *
- * the component is primarily a container that follows the targeted element.
- * the tooltip will be invisible and disabled if another element covered the targeted element or its simply out of view
- * the tooltip will close and dispatch a CustomEvent of "tooltipClosed"
+ * The component is primarily a container that follows the targeted element.
+ * The coachmark will be invisible and disabled if another element covered the targeted element or its simply out of view.
+ * The coachmark will close and dispatch a CustomEvent of `gds-ui-state`
  *
  * Note: the component can only view one coachmark at the time therefore the tooltip won't be
  * rendered in second storybook panel and testing the tooltip behaviour will be in the first panel only

--- a/libs/core/src/components/coachmark/coachmark.stories.ts
+++ b/libs/core/src/components/coachmark/coachmark.stories.ts
@@ -15,6 +15,8 @@ import './index.ts'
  * Note: the component can only view one coachmark at the time therefore the tooltip won't be
  * rendered in second storybook panel and testing the tooltip behaviour will be in the first panel only
  *
+ * @status beta
+ *
  */
 const meta: Meta = {
   title: 'Docs/Components/Coachmark',

--- a/libs/core/src/components/coachmark/coachmark.styles.ts
+++ b/libs/core/src/components/coachmark/coachmark.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'lit'
 //To do later: add classes for light theme
 const style = css`
-  .gds-coachmark {
+  #body {
     visibility: hidden;
     position: absolute;
     z-index: 1060;
@@ -15,7 +15,7 @@ const style = css`
     transition: opacity 0.3s;
   }
 
-  #gds-arrow {
+  #arrow {
     box-sizing: border-box;
     z-index: -1;
     position: absolute;

--- a/libs/core/src/components/coachmark/coachmark.test.ts
+++ b/libs/core/src/components/coachmark/coachmark.test.ts
@@ -1,5 +1,10 @@
 import { expect } from '@esm-bundle/chai'
-import { fixture, html as testingHtml, waitUntil } from '@open-wc/testing'
+import {
+  aTimeout,
+  fixture,
+  html as testingHtml,
+  waitUntil,
+} from '@open-wc/testing'
 
 import '@sebgroup/green-core/components/coachmark'
 import type { GdsCoachmark } from '@sebgroup/green-core/components/coachmark'
@@ -22,43 +27,26 @@ describe('<gds-coachmark>', () => {
         html`<gds-coachmark></gds-coachmark>`,
       )
 
-      el.target = ['#someTarget']
-
-      await el.updateComplete
-
-      const container = el.shadowRoot?.querySelector(
-        'div[class*="gds-coachmark"]',
-      )
-
-      expect(container).to.exist
+      expect(el.shadowRoot).to.exist
     })
 
     it('should render slot', async () => {
       const el = await fixture<GdsCoachmark>(
-        html`<gds-coachmark><span>Test</span></gds-coachmark>`,
+        html`<gds-coachmark .target=${['#target']}
+          ><span>Test</span></gds-coachmark
+        >`,
       )
-
-      el.target = ['#someTarget']
-
-      await el.updateComplete
 
       const slotEl = el.shadowRoot?.querySelector('slot')
       expect(slotEl).to.exist
-
-      const slottedEl = el.querySelector('span')
-      expect(slottedEl).to.exist
     })
 
     it('should render arrow div', async () => {
       const el = await fixture<GdsCoachmark>(
-        html`<gds-coachmark></gds-coachmark>`,
+        html`<gds-coachmark .target=${['#target']}></gds-coachmark>`,
       )
 
-      el.target = ['#someTarget']
-
-      await el.updateComplete
-
-      const arrow = el.shadowRoot?.querySelector('#gds-arrow')
+      const arrow = el.shadowRoot?.querySelector('#arrow')
 
       expect(arrow).to.exist
     })
@@ -71,8 +59,6 @@ describe('<gds-coachmark>', () => {
           <div>Content</div>
         </gds-coachmark>`,
       )
-
-      el.target = ['#someTarget']
 
       await el.updateComplete
 
@@ -88,7 +74,6 @@ describe('<gds-coachmark>', () => {
         </gds-coachmark>`,
       )
 
-      el.target = ['#someTarget']
       el._isVisible = true
 
       await el.updateComplete
@@ -104,13 +89,53 @@ describe('<gds-coachmark>', () => {
         </gds-coachmark>`,
       )
 
-      el.target = ['#someTarget']
       el._isVisible = true
 
       await el.updateComplete
 
       await sendKeys({ press: 'Escape' })
       await waitUntil(() => !el._isVisible)
+    })
+  })
+
+  describe('API', () => {
+    it('should find target element', async () => {
+      const el = await fixture(
+        html`<div>
+          <div
+            style="position: absolute; top: 100px; left: 100px"
+            id="target"
+          ></div>
+          <gds-coachmark id="coachmark" .target=${['#target']}></gds-coachmark>
+        </div>`,
+      )
+
+      const coachmark = el.querySelector('#coachmark') as GdsCoachmark
+      await coachmark.updateComplete
+
+      const target = el.querySelector('#target')
+
+      expect(coachmark.targetElement).to.equal(target)
+    })
+
+    it('should fire gds-ui-state event when closing', async () => {
+      const el = await fixture<GdsCoachmark>(
+        html`<gds-coachmark .target=${['#target']}>
+          <div>Content</div>
+        </gds-coachmark>`,
+      )
+
+      el._isVisible = true
+
+      await el.updateComplete
+
+      const eventPromise = new Promise((resolve) => {
+        el.addEventListener('gds-ui-state', resolve, { once: true })
+      })
+
+      document.body.click()
+
+      await eventPromise
     })
   })
 })

--- a/libs/core/src/components/coachmark/coachmark.ts
+++ b/libs/core/src/components/coachmark/coachmark.ts
@@ -301,12 +301,12 @@ export class GdsCoachmark extends GdsElement {
       () => html`
         <div
           role="dialog"
-          class="gds-coachmark"
+          id="body"
           aria-label="Coachmark"
           ${ref(this.#cardRef) as HTMLElement}
         >
           <slot></slot>
-          <div id="gds-arrow" ${ref(this.#arrowRef) as HTMLElement}></div>
+          <div id="arrow" ${ref(this.#arrowRef) as HTMLElement}></div>
         </div>
       `,
       () => html``,

--- a/libs/core/src/components/coachmark/coachmark.ts
+++ b/libs/core/src/components/coachmark/coachmark.ts
@@ -195,7 +195,7 @@ export class GdsCoachmark extends GdsElement {
           name: 'detectOverflow',
           async fn(positionState) {
             const overflow = await detectOverflow(positionState, {
-              boundary: document.querySelector('main'),
+              boundary: document.body,
               rootBoundary: 'document',
               altBoundary: true,
               padding: {

--- a/libs/core/src/components/coachmark/coachmark.ts
+++ b/libs/core/src/components/coachmark/coachmark.ts
@@ -55,7 +55,7 @@ export class GdsCoachmark extends GdsElement {
    * The accessible label of the coachmark.
    */
   @property()
-  label: string = 'Coachmark'
+  label = 'Coachmark'
 
   /**
    * A callback that can be used to set the visibility of the coachmark based on your criteria.

--- a/libs/core/src/components/coachmark/coachmark.ts
+++ b/libs/core/src/components/coachmark/coachmark.ts
@@ -25,6 +25,8 @@ import { GdsElement } from '../../gds-element'
  * @slot body - placeholder for the content of the tooltip.
  *
  * @event tooltipClosed - dispatched when the tooltip is closed
+ *
+ * @status beta
  */
 @gdsCustomElement('gds-coachmark')
 export class GdsCoachmark extends GdsElement {

--- a/libs/core/src/components/coachmark/coachmark.ts
+++ b/libs/core/src/components/coachmark/coachmark.ts
@@ -31,29 +31,6 @@ export class GdsCoachmark extends GdsElement {
   static styles = styles
 
   /**
-   * @internal
-   */
-  static shadowRootOptions: ShadowRootInit = {
-    mode: 'open',
-    delegatesFocus: true,
-  }
-
-  #cardRef: Ref<Element> = createRef()
-  #arrowRef: Ref<Element> = createRef()
-  #targetedElement: HTMLElement | undefined = undefined
-  #autoUpdateCleanupFn: (() => void) | undefined
-
-  /**
-   *Tracks the visibility of the tooltip (readonly)
-   */
-  @state() _isVisible = false
-
-  /**
-   *Used to prevent closing the tooltip if it's not visible (readonly)
-   */
-  @state() _preventClose = false
-
-  /**
    * The placement of the popover relative to the trigger.
    * Accepts any of the placements supported by Floating UI.
    */
@@ -83,6 +60,17 @@ export class GdsCoachmark extends GdsElement {
     target: HTMLElement,
     computedVisibility: boolean,
   ) => boolean = (_self, _target, computedVisibility) => computedVisibility
+
+  // Tracks the visibility of the tooltip (readonly)
+  @state() _isVisible = false
+
+  // Used to prevent closing the tooltip if it's not visible (readonly)
+  @state() _preventClose = false
+
+  #cardRef: Ref<Element> = createRef()
+  #arrowRef: Ref<Element> = createRef()
+  #targetedElement: HTMLElement | undefined = undefined
+  #autoUpdateCleanupFn: (() => void) | undefined
 
   connectedCallback(): void {
     super.connectedCallback()

--- a/libs/core/src/components/coachmark/coachmark.ts
+++ b/libs/core/src/components/coachmark/coachmark.ts
@@ -72,6 +72,18 @@ export class GdsCoachmark extends GdsElement {
   @property({ attribute: false })
   target: string[] = []
 
+  /**
+   * A callback that can be used to set the visibility of the coachmark based on your criteria.
+   *
+   * The default computed visibility, based on visibility and overlap of the target element, is supplied as the third argument.
+   */
+  @property({ attribute: false })
+  computeVisibility: (
+    self: GdsCoachmark,
+    target: HTMLElement,
+    computedVisibility: boolean,
+  ) => boolean = (_self, _target, computedVisibility) => computedVisibility
+
   connectedCallback(): void {
     super.connectedCallback()
 
@@ -223,14 +235,16 @@ export class GdsCoachmark extends GdsElement {
     if (!this.#targetedElement) return false
 
     const isOutOfBound = this.#isElementOutsideView(this.#targetedElement)
-    const isVisible = this.#targetedElement.checkVisibility()
+    const targetIsVisible = this.#targetedElement.checkVisibility()
     const isOverlapping =
       this.overlappedBy.length === 0
         ? false
         : this.#checkOverlap(this.overlappedBy)
 
-    return (
-      !isOverlapping && !isOutOfBound && isVisible && window.innerWidth > 580
+    return this.computeVisibility(
+      this,
+      this.#targetedElement,
+      !isOverlapping && !isOutOfBound && targetIsVisible,
     )
   }
 


### PR DESCRIPTION
* Add `computeVisibility` callback for customizing visibility
* Remove hard coded dependence on `main` element
* Rename close event to `gds-ui-state` to align with other components

And some other minor tweaks/alignments