### PR TITLE
Tokens: Typography 

### DIFF
--- a/.changeset/lazy-pumas-try.md
+++ b/.changeset/lazy-pumas-try.md
@@ -1,0 +1,6 @@
+---
+'@sebgroup/green-tokens': minor
+---
+
+Add all typography sizes and colors
+Fixes: #1542

--- a/.changeset/lazy-pumas-try.md
+++ b/.changeset/lazy-pumas-try.md
@@ -2,5 +2,29 @@
 '@sebgroup/green-tokens': minor
 ---
 
-Add all typography sizes and colors
+Add all typography sizes and colors new structure
+
 Fixes: #1542
+
+The following typography sizes renamed:
+
+label-overline
+label-input-medium
+label-input-large
+label-information-medium
+label-information-large
+label-small
+label-medium
+label-large
+body-small
+body-medium
+body-large
+title-small
+title-medium
+title-large
+headline-small
+headline-medium
+headline-large
+display-small
+display-medium
+display-large

--- a/.changeset/thick-lizards-attack.md
+++ b/.changeset/thick-lizards-attack.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": patch
+---
+
+Import shadow tokens from lib

--- a/.changeset/thick-lizards-attack.md
+++ b/.changeset/thick-lizards-attack.md
@@ -1,5 +1,10 @@
 ---
-"@sebgroup/green-core": patch
+'@sebgroup/green-core': minor
 ---
 
-Import shadow tokens from lib
+1. Refactored the scale, removing `title` sizes in favor of `heading`.
+2. Aligned size scale with `h1-h6`, corresponding to `heading-xl` through `heading-2xs`.
+3. Imported and generate shadow tokens from the library.
+4. Applied styles directly to the tag.
+5. Added default styles for `h1-h6`, `paragraph`, and `strong` tags.
+6. Implemented sanitization to ensure valid HTML tag names.

--- a/libs/core/src/components/button/fab/fab.styles.ts
+++ b/libs/core/src/components/button/fab/fab.styles.ts
@@ -7,10 +7,7 @@ const style = css`
   }
 
   .button {
-    /* TODO: Tokens! */
-    box-shadow:
-      0px 8px 12px 0px rgba(27, 27, 24, 0.15),
-      0px 0px 1px 0px rgba(13, 13, 12, 0.3);
+    box-shadow: var(--gds-shadow-m);
     height: calc(var(--_size) + 0.5rem);
   }
 `

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -109,19 +109,23 @@ export const Card: Story = {
   ...DefaultParams,
   name: 'Tags',
   render: (args) =>
-    html`<gds-flex direction="column" gap="m">
-      <gds-text size="heading-xl" tag="h1">H1</gds-text>
-      <gds-text size="heading-l" tag="h2">H2</gds-text>
-      <gds-text size="heading-m" tag="h3">H3</gds-text>
-      <gds-text size="heading-s" tag="h4">H4</gds-text>
-      <gds-text size="heading-xs" tag="h5">H5</gds-text>
-      <gds-text size="heading-2xs" tag="h6">H6</gds-text>
-      <gds-text>Paragraph ( Default )</gds-text>
-      <gds-text tag="span">Span</gds-text>
-      <gds-text tag="em">Em</gds-text>
-      <gds-text tag="mark">Mark</gds-text>
-      <gds-text tag="strong">strong</gds-text>
-      <gds-text tag="small">small</gds-text>
+    html`<gds-flex direction="column" gap="2xl">
+      <gds-flex direction="column" gap="m">
+        <gds-text>Paragraph ( Default )</gds-text>
+        <gds-text tag="span">Span</gds-text>
+        <gds-text tag="em">Em</gds-text>
+        <gds-text tag="mark">Mark</gds-text>
+        <gds-text tag="strong">strong</gds-text>
+        <gds-text tag="small">small</gds-text>
+      </gds-flex>
+      <gds-flex direction="column" gap="m">
+        <gds-text tag="h1">H1</gds-text>
+        <gds-text tag="h2">H2</gds-text>
+        <gds-text tag="h3">H3</gds-text>
+        <gds-text tag="h4">H4</gds-text>
+        <gds-text tag="h5">H5</gds-text>
+        <gds-text tag="h6">H6</gds-text>
+      </gds-flex>
     </gds-flex>`,
 }
 

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -31,26 +31,29 @@ const DefaultParams: Story = {
   argTypes: {
     size: {
       options: [
-        'label-overline',
-        'label-input-medium',
-        'label-input-large',
-        'label-information-medium',
-        'label-information-large',
-        'label-small',
-        'label-medium',
-        'label-large',
-        'body-small',
-        'body-medium',
-        'body-large',
-        'title-small',
-        'title-medium',
-        'title-large',
-        'headline-small',
-        'headline-medium',
-        'headline-large',
-        'display-small',
-        'display-medium',
-        'display-large',
+        'headline-l',
+        'headline-m',
+        'headline-s',
+        'title-l',
+        'title-m',
+        'title-s',
+        'detail-m',
+        'detail-s',
+        'detail-xs',
+        'body-l',
+        'body-m',
+        'body-s',
+        'display-2xl',
+        'display-xl',
+        'display-l',
+        'display-m',
+        'display-s ',
+        'preamble-2xl',
+        'preamble-xl',
+        'preamble-l',
+        'preamble-m',
+        'preamble-s',
+        'preamble-xs',
       ],
       control: { type: 'select' },
     },
@@ -120,33 +123,13 @@ export const Card: Story = {
     </gds-flex>`,
 }
 
-export const Size: Story = {
-  name: 'Labels',
+export const Headline: Story = {
+  name: 'Headline',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="label-overline">Label: Overline</gds-text>
-      <gds-text size="label-input-medium">Label: Input Medium</gds-text>
-      <gds-text size="label-input-large">Label: Input Large</gds-text>
-      <gds-text size="label-information-medium"
-        >Label: Input Information Medium</gds-text
-      >
-      <gds-text size="label-information-large"
-        >Label: Input Information Large</gds-text
-      >
-      <gds-text size="label-small">Label: Input Small</gds-text>
-      <gds-text size="label-medium">Label: Input Medium</gds-text>
-      <gds-text size="label-large">Label: Input Large</gds-text>
-    </gds-flex>
-  `,
-}
-
-export const Body: Story = {
-  name: 'Body',
-  render: (args) => html`
-    <gds-flex direction="column" gap="m">
-      <gds-text size="body-small">Body: Small</gds-text>
-      <gds-text size="body-medium">Body: Medium</gds-text>
-      <gds-text size="body-large">Body: Large</gds-text>
+      <gds-text size="headline-l">Headline Large</gds-text>
+      <gds-text size="headline-m">Headline Medium</gds-text>
+      <gds-text size="headline-s">Headline Small</gds-text>
     </gds-flex>
   `,
 }
@@ -155,20 +138,31 @@ export const Title: Story = {
   name: 'Title',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="title-small">Title: Small</gds-text>
-      <gds-text size="title-medium">Title: Medium</gds-text>
-      <gds-text size="title-large">Title: Large</gds-text>
+      <gds-text size="title-l">Title Large</gds-text>
+      <gds-text size="title-m">Title Medium</gds-text>
+      <gds-text size="title-s">Title Small</gds-text>
     </gds-flex>
   `,
 }
 
-export const Headline: Story = {
-  name: 'Headline',
+export const Detail: Story = {
+  name: 'Detail',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="headline-small">Headline: Small</gds-text>
-      <gds-text size="headline-medium">Headline: Medium</gds-text>
-      <gds-text size="headline-large">Headline: Large</gds-text>
+      <gds-text size="detail-m">Detail Medium</gds-text>
+      <gds-text size="detail-s">Detail Small</gds-text>
+      <gds-text size="detail-xs">Detail Extra Small</gds-text>
+    </gds-flex>
+  `,
+}
+
+export const Body: Story = {
+  name: 'Body',
+  render: (args) => html`
+    <gds-flex direction="column" gap="m">
+      <gds-text size="body-l">Body Large</gds-text>
+      <gds-text size="body-m">Body Medium</gds-text>
+      <gds-text size="body-s">Body Small</gds-text>
     </gds-flex>
   `,
 }
@@ -177,9 +171,25 @@ export const Display: Story = {
   name: 'Display',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="display-small">Display: Small</gds-text>
-      <gds-text size="display-medium">Display: Medium</gds-text>
-      <gds-text size="display-large">Display: Large</gds-text>
+      <gds-text size="display-2xl">Display 2XL</gds-text>
+      <gds-text size="display-xl">Display XL</gds-text>
+      <gds-text size="display-l">Display Large</gds-text>
+      <gds-text size="display-m">Display Medium</gds-text>
+      <gds-text size="display-s">Display Small</gds-text>
+    </gds-flex>
+  `,
+}
+
+export const Preamble: Story = {
+  name: 'Preamble',
+  render: (args) => html`
+    <gds-flex direction="column" gap="m">
+      <gds-text size="preamble-2xl">Preamble 2XL</gds-text>
+      <gds-text size="preamble-xl">Preamble XL</gds-text>
+      <gds-text size="preamble-l">Preamble Large</gds-text>
+      <gds-text size="preamble-m">Preamble Medium</gds-text>
+      <gds-text size="preamble-s">Preamble Small</gds-text>
+      <gds-text size="preamble-xs">Preamble Extra Small</gds-text>
     </gds-flex>
   `,
 }
@@ -193,16 +203,16 @@ export const Lines: Story = {
     <gds-flex direction="column" gap="2xl">
       <gds-flex direction="column" gap="m">
         <gds-divider></gds-divider>
-        <gds-text tag="h2" size="body-small">Lines:2</gds-text>
-        <gds-text size="display-small" lines="2">
+        <gds-text tag="h2" size="body-s">Lines:2</gds-text>
+        <gds-text size="display-s" lines="2">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </gds-text>
       </gds-flex>
       <gds-flex direction="column" gap="m">
         <gds-divider></gds-divider>
-        <gds-text tag="h2" size="body-small">Lines:3</gds-text>
-        <gds-text size="display-medium" lines="3">
+        <gds-text tag="h2" size="body-s">Lines:3</gds-text>
+        <gds-text size="display-m" lines="3">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
           ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -213,8 +223,8 @@ export const Lines: Story = {
       </gds-flex>
       <gds-flex direction="column" gap="m">
         <gds-divider></gds-divider>
-        <gds-text tag="h2" size="body-small">Lines:4</gds-text>
-        <gds-text size="display-large" lines="4">
+        <gds-text tag="h2" size="body-s">Lines:4</gds-text>
+        <gds-text size="display-l" lines="4">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
           ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -226,3 +236,75 @@ export const Lines: Story = {
     </gds-flex>
   `,
 }
+
+// Sizes
+// headline-l: 32
+// headline-m: 28
+// headline-s: 24
+
+// title-l: 20
+// title-m: 16
+// title-s: 14
+
+// detail-m: 16
+// detail-s: 14
+// detail-xs: 12
+
+// body-l: 20
+// body-m: 16
+// body-s: 14
+
+// display-xxl: 82
+// display-xl: 64
+// display-l: 48
+// display-m: 36
+// display-s: 32
+
+// headline-l: 32
+// headline-m: 24
+// headline-s: 20
+
+// preamble-xxl: 32
+// preamble-xl: 28
+// preamble-l: 24
+// preamble-m: 20
+// preamble-s: 18
+// preamble-xs: 16
+
+// Line height
+// Line height
+// Line height
+// Line height
+
+// headline-l: 40
+// headline-m: 36
+// headline-s: 30
+
+// title-l: 26
+// title-m: 24
+// title-s: 20
+
+// detail-m: 20
+// detail-s: 18
+// detail-xs: 16
+
+// body-l: 26
+// body-m: 24
+// body-s: 20
+
+// display-xxl: 90
+// display-xl: 72
+// display-l: 56
+// display-m: 44
+// display-s: 40
+
+// headline-l: 40
+// headline-m: 32
+// headline-s: 28
+
+// preamble-xxl: 40
+// preamble-xl: 36
+// preamble-l: 32
+// preamble-m: 28
+// preamble-s: 26
+// preamble-xs: 24

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -123,6 +123,19 @@ export const Card: Story = {
     </gds-flex>`,
 }
 
+export const Weight: Story = {
+  ...DefaultParams,
+  name: 'Weight',
+  render: (args) =>
+    html`<gds-flex direction="column" gap="m">
+      <gds-text weight="bold">Bold (700)</gds-text>
+      <gds-text weight="medium">Medium (500)</gds-text>
+      <gds-text weight="book">Book (450)</gds-text>
+      <gds-text weight="regular">Regular (400)</gds-text>
+      <gds-text weight="light">Light (300)</gds-text>
+    </gds-flex>`,
+}
+
 export const Headline: Story = {
   name: 'Headline',
   render: (args) => html`

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -96,14 +96,13 @@ const DefaultParams: Story = {
 }
 
 /**
- * # Headings
  *
  * In order to have more flexibility the tag it self and the sizing are controlled by the user.
  * The `gds-text` accepts the `tag` property which will render the text with the specified tag and the `size` property which will render the text with the specified size based on the tokens
  *
- * Tag: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `span`, `em`, `mark`, `strong`, `small`, `sup` etc.
+ * Example: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `span`, `em`, `mark`, `strong`, `small` etc.
  *
- * #### The defualt tag is `p` and the defualt size is `body-m`
+ * The defualt tag is `p` and the defualt size is `body-m`
  */
 
 export const Card: Story = {
@@ -139,17 +138,22 @@ export const Weight: Story = {
     </gds-flex>`,
 }
 
+/**
+ * > Headings in the `gds-text` component come with predefined sizes based on design tokens, and the `tag` property is used to define the heading level.
+ * > For example, using `tag="h1"` will automatically apply the `heading-xl` size, so specifying the `size` property is not necessary.
+ * > However, the `size` property can still be used to override the default size if needed.
+ * > This provides flexibility in using the `gds-text` component across different contexts while ensuring consistent typography.
+ */
 export const Heading: Story = {
   name: 'Heading',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="heading-2xs">Heading 2XS</gds-text>
-      <gds-text size="heading-xs">Heading XS</gds-text>
-      <gds-text size="heading-s">Heading Small</gds-text>
-      <gds-text size="heading-s">Heading Small</gds-text>
-      <gds-text size="heading-m">Heading Medium</gds-text>
-      <gds-text size="heading-l">Heading Large</gds-text>
-      <gds-text size="heading-xl">Heading Extra Large</gds-text>
+      <gds-text tag="h6" size="heading-2xs">H6: Heading 2XS</gds-text>
+      <gds-text tag="h5" size="heading-xs">H5: Heading XS</gds-text>
+      <gds-text tag="h4" size="heading-s">H4: Heading Small</gds-text>
+      <gds-text tag="h3" size="heading-m">H3: Heading Medium</gds-text>
+      <gds-text tag="h2" size="heading-l">H2: Heading Large</gds-text>
+      <gds-text tag="h1" size="heading-xl">H1: Heading Extra Large</gds-text>
     </gds-flex>
   `,
 }

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -140,9 +140,9 @@ export const Headline: Story = {
   name: 'Headline',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="headline-l">Headline Large</gds-text>
-      <gds-text size="headline-m">Headline Medium</gds-text>
       <gds-text size="headline-s">Headline Small</gds-text>
+      <gds-text size="headline-m">Headline Medium</gds-text>
+      <gds-text size="headline-l">Headline Large</gds-text>
     </gds-flex>
   `,
 }
@@ -151,9 +151,9 @@ export const Title: Story = {
   name: 'Title',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="title-l">Title Large</gds-text>
-      <gds-text size="title-m">Title Medium</gds-text>
       <gds-text size="title-s">Title Small</gds-text>
+      <gds-text size="title-m">Title Medium</gds-text>
+      <gds-text size="title-l">Title Large</gds-text>
     </gds-flex>
   `,
 }
@@ -162,9 +162,9 @@ export const Detail: Story = {
   name: 'Detail',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="detail-m">Detail Medium</gds-text>
-      <gds-text size="detail-s">Detail Small</gds-text>
       <gds-text size="detail-xs">Detail Extra Small</gds-text>
+      <gds-text size="detail-s">Detail Small</gds-text>
+      <gds-text size="detail-m">Detail Medium</gds-text>
     </gds-flex>
   `,
 }
@@ -173,9 +173,9 @@ export const Body: Story = {
   name: 'Body',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="body-l">Body Large</gds-text>
-      <gds-text size="body-m">Body Medium</gds-text>
       <gds-text size="body-s">Body Small</gds-text>
+      <gds-text size="body-m">Body Medium</gds-text>
+      <gds-text size="body-l">Body Large</gds-text>
     </gds-flex>
   `,
 }
@@ -184,11 +184,11 @@ export const Display: Story = {
   name: 'Display',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="display-2xl">Display 2XL</gds-text>
-      <gds-text size="display-xl">Display XL</gds-text>
-      <gds-text size="display-l">Display Large</gds-text>
-      <gds-text size="display-m">Display Medium</gds-text>
       <gds-text size="display-s">Display Small</gds-text>
+      <gds-text size="display-m">Display Medium</gds-text>
+      <gds-text size="display-l">Display Large</gds-text>
+      <gds-text size="display-xl">Display XL</gds-text>
+      <gds-text size="display-2xl">Display 2XL</gds-text>
     </gds-flex>
   `,
 }
@@ -197,12 +197,12 @@ export const Preamble: Story = {
   name: 'Preamble',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="preamble-2xl">Preamble 2XL</gds-text>
-      <gds-text size="preamble-xl">Preamble XL</gds-text>
-      <gds-text size="preamble-l">Preamble Large</gds-text>
-      <gds-text size="preamble-m">Preamble Medium</gds-text>
-      <gds-text size="preamble-s">Preamble Small</gds-text>
       <gds-text size="preamble-xs">Preamble Extra Small</gds-text>
+      <gds-text size="preamble-s">Preamble Small</gds-text>
+      <gds-text size="preamble-m">Preamble Medium</gds-text>
+      <gds-text size="preamble-l">Preamble Large</gds-text>
+      <gds-text size="preamble-xl">Preamble XL</gds-text>
+      <gds-text size="preamble-2xl">Preamble 2XL</gds-text>
     </gds-flex>
   `,
 }
@@ -249,75 +249,3 @@ export const Lines: Story = {
     </gds-flex>
   `,
 }
-
-// Sizes
-// headline-l: 32
-// headline-m: 28
-// headline-s: 24
-
-// title-l: 20
-// title-m: 16
-// title-s: 14
-
-// detail-m: 16
-// detail-s: 14
-// detail-xs: 12
-
-// body-l: 20
-// body-m: 16
-// body-s: 14
-
-// display-xxl: 82
-// display-xl: 64
-// display-l: 48
-// display-m: 36
-// display-s: 32
-
-// headline-l: 32
-// headline-m: 24
-// headline-s: 20
-
-// preamble-xxl: 32
-// preamble-xl: 28
-// preamble-l: 24
-// preamble-m: 20
-// preamble-s: 18
-// preamble-xs: 16
-
-// Line height
-// Line height
-// Line height
-// Line height
-
-// headline-l: 40
-// headline-m: 36
-// headline-s: 30
-
-// title-l: 26
-// title-m: 24
-// title-s: 20
-
-// detail-m: 20
-// detail-s: 18
-// detail-xs: 16
-
-// body-l: 26
-// body-m: 24
-// body-s: 20
-
-// display-xxl: 90
-// display-xl: 72
-// display-l: 56
-// display-m: 44
-// display-s: 40
-
-// headline-l: 40
-// headline-m: 32
-// headline-s: 28
-
-// preamble-xxl: 40
-// preamble-xl: 36
-// preamble-l: 32
-// preamble-m: 28
-// preamble-s: 26
-// preamble-xs: 24

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -118,7 +118,7 @@ export const Card: Story = {
       <gds-text size="heading-s" tag="h4">H4</gds-text>
       <gds-text size="" tag="h5">H5</gds-text>
       <gds-text size="" tag="h6">H6</gds-text>
-      <gds-text sizee="body-m">Paragraph</gds-text>
+      <gds-text>Paragraph ( Default )</gds-text>
       <gds-text tag="span">Span</gds-text>
       <gds-text tag="em">Em</gds-text>
       <gds-text tag="mark">Mark</gds-text>

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -8,6 +8,8 @@ import { html } from 'lit'
 
 /**
  * The `gds-text`
+ * The gds-text element is designed to display text content flexibly. You can easily change the HTML tag it uses, wrap the text, set a maximum character length, and apply line clamping. It also allows you to adjust the text size based on design tokens that work together with line height and font size.
+ *
  *
  * ## Usage
  *
@@ -100,9 +102,9 @@ const DefaultParams: Story = {
  * In order to have more flexibility the tag it self and the sizing are controlled by the user.
  * The `gds-text` accepts the `tag` property which will render the text with the specified tag and the `size` property which will render the text with the specified size based on the tokens
  *
- * Tag: h1, h2, h3, h4, h5, h6, p, span, em, mark, strong etc.
+ * Tag: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `span`, `em`, `mark`, `strong`, `small`, `sup` etc.
  *
- * #### The defualt tag is `p` and the defualt size is `body-medium`
+ * #### The defualt tag is `p` and the defualt size is `body-m`
  */
 
 export const Card: Story = {
@@ -110,17 +112,18 @@ export const Card: Story = {
   name: 'Tags',
   render: (args) =>
     html`<gds-flex direction="column" gap="m">
-      <gds-text tag="h1">H1</gds-text>
-      <gds-text tag="h2">H2</gds-text>
-      <gds-text tag="h3">H3</gds-text>
-      <gds-text tag="h4">H4</gds-text>
-      <gds-text tag="h5">H5</gds-text>
-      <gds-text tag="h6">H6</gds-text>
-      <gds-text>Paragraph</gds-text>
+      <gds-text size="heading-xl" tag="h1">H1</gds-text>
+      <gds-text size="heading-l" tag="h2">H2</gds-text>
+      <gds-text size="heading-m" tag="h3">H3</gds-text>
+      <gds-text size="heading-s" tag="h4">H4</gds-text>
+      <gds-text size="" tag="h5">H5</gds-text>
+      <gds-text size="" tag="h6">H6</gds-text>
+      <gds-text sizee="body-m">Paragraph</gds-text>
       <gds-text tag="span">Span</gds-text>
       <gds-text tag="em">Em</gds-text>
       <gds-text tag="mark">Mark</gds-text>
       <gds-text tag="strong">strong</gds-text>
+      <gds-text tag="small">small</gds-text>
     </gds-flex>`,
 }
 

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -102,7 +102,7 @@ const DefaultParams: Story = {
  *
  * Example: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `span`, `em`, `mark`, `strong`, `small` etc.
  *
- * The defualt tag is `p` and the defualt size is `body-m`
+ * The default tag is `span` and the default size is `body-m`
  */
 
 export const Card: Story = {
@@ -111,8 +111,8 @@ export const Card: Story = {
   render: (args) =>
     html`<gds-flex direction="column" gap="2xl">
       <gds-flex direction="column" gap="m">
-        <gds-text>Paragraph ( Default )</gds-text>
-        <gds-text tag="span">Span</gds-text>
+        <gds-text>Span ( Default )</gds-text>
+        <gds-text tag="p">Paragraph </gds-text>
         <gds-text tag="em">Em</gds-text>
         <gds-text tag="mark">Mark</gds-text>
         <gds-text tag="strong">strong</gds-text>

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -148,12 +148,12 @@ export const Heading: Story = {
   name: 'Heading',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text tag="h6" size="heading-2xs">H6: Heading 2XS</gds-text>
-      <gds-text tag="h5" size="heading-xs">H5: Heading XS</gds-text>
-      <gds-text tag="h4" size="heading-s">H4: Heading Small</gds-text>
-      <gds-text tag="h3" size="heading-m">H3: Heading Medium</gds-text>
-      <gds-text tag="h2" size="heading-l">H2: Heading Large</gds-text>
-      <gds-text tag="h1" size="heading-xl">H1: Heading Extra Large</gds-text>
+      <gds-text tag="h6">H6: Heading 2XS</gds-text>
+      <gds-text tag="h5">H5: Heading XS</gds-text>
+      <gds-text tag="h4">H4: Heading Small</gds-text>
+      <gds-text tag="h3">H3: Heading Medium</gds-text>
+      <gds-text tag="h2">H2: Heading Large</gds-text>
+      <gds-text tag="h1">H1: Heading Extra Large</gds-text>
     </gds-flex>
   `,
 }

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -31,6 +31,7 @@ const DefaultParams: Story = {
   argTypes: {
     size: {
       options: [
+        'headline-xl',
         'headline-l',
         'headline-m',
         'headline-s',
@@ -143,6 +144,7 @@ export const Headline: Story = {
       <gds-text size="headline-s">Headline Small</gds-text>
       <gds-text size="headline-m">Headline Medium</gds-text>
       <gds-text size="headline-l">Headline Large</gds-text>
+      <gds-text size="headline-xl">Headline Extra Large</gds-text>
     </gds-flex>
   `,
 }

--- a/libs/core/src/components/content/text/text.stories.ts
+++ b/libs/core/src/components/content/text/text.stories.ts
@@ -33,13 +33,12 @@ const DefaultParams: Story = {
   argTypes: {
     size: {
       options: [
-        'headline-xl',
-        'headline-l',
-        'headline-m',
-        'headline-s',
-        'title-l',
-        'title-m',
-        'title-s',
+        'heading-xl',
+        'heading-l',
+        'heading-m',
+        'heading-s',
+        'heading-xs',
+        'heading-2xs',
         'detail-m',
         'detail-s',
         'detail-xs',
@@ -116,8 +115,8 @@ export const Card: Story = {
       <gds-text size="heading-l" tag="h2">H2</gds-text>
       <gds-text size="heading-m" tag="h3">H3</gds-text>
       <gds-text size="heading-s" tag="h4">H4</gds-text>
-      <gds-text size="" tag="h5">H5</gds-text>
-      <gds-text size="" tag="h6">H6</gds-text>
+      <gds-text size="heading-xs" tag="h5">H5</gds-text>
+      <gds-text size="heading-2xs" tag="h6">H6</gds-text>
       <gds-text>Paragraph ( Default )</gds-text>
       <gds-text tag="span">Span</gds-text>
       <gds-text tag="em">Em</gds-text>
@@ -140,25 +139,17 @@ export const Weight: Story = {
     </gds-flex>`,
 }
 
-export const Headline: Story = {
-  name: 'Headline',
+export const Heading: Story = {
+  name: 'Heading',
   render: (args) => html`
     <gds-flex direction="column" gap="m">
-      <gds-text size="headline-s">Headline Small</gds-text>
-      <gds-text size="headline-m">Headline Medium</gds-text>
-      <gds-text size="headline-l">Headline Large</gds-text>
-      <gds-text size="headline-xl">Headline Extra Large</gds-text>
-    </gds-flex>
-  `,
-}
-
-export const Title: Story = {
-  name: 'Title',
-  render: (args) => html`
-    <gds-flex direction="column" gap="m">
-      <gds-text size="title-s">Title Small</gds-text>
-      <gds-text size="title-m">Title Medium</gds-text>
-      <gds-text size="title-l">Title Large</gds-text>
+      <gds-text size="heading-2xs">Heading 2XS</gds-text>
+      <gds-text size="heading-xs">Heading XS</gds-text>
+      <gds-text size="heading-s">Heading Small</gds-text>
+      <gds-text size="heading-s">Heading Small</gds-text>
+      <gds-text size="heading-m">Heading Medium</gds-text>
+      <gds-text size="heading-l">Heading Large</gds-text>
+      <gds-text size="heading-xl">Heading Extra Large</gds-text>
     </gds-flex>
   `,
 }

--- a/libs/core/src/components/content/text/text.style.css.ts
+++ b/libs/core/src/components/content/text/text.style.css.ts
@@ -13,14 +13,42 @@ const style = css`
     text-wrap: inherit;
   }
 
-  // TODO: Add defaults for H1-H6 and p
-  // Example:
-  // :host(:not([size])) {
-  // h1 {
-  //   font-size: var(--font-size-body-m);
-  //   line-height: var(--line-height-body-m);
-  // }
-  // }
+  :host(:not([size])) {
+    h1 {
+      font-size: var(--gds-text-size-heading-xl);
+      line-height: var(--gds-text-line-height-heading-xl);
+    }
+
+    h2 {
+      font-size: var(--gds-text-size-heading-l);
+      line-height: var(--gds-text-line-height-heading-l);
+    }
+
+    h3 {
+      font-size: var(--gds-text-size-heading-m);
+      line-height: var(--gds-text-line-height-heading-m);
+    }
+
+    h4 {
+      font-size: var(--gds-text-size-heading-s);
+      line-height: var(--gds-text-line-height-heading-s);
+    }
+
+    h5 {
+      font-size: var(--gds-text-size-heading-xs);
+      line-height: var(--gds-text-line-height-heading-xs);
+    }
+
+    h6 {
+      font-size: var(--gds-text-size-heading-2xs);
+      line-height: var(--gds-text-line-height-heading-2xs);
+    }
+
+    p {
+      font-size: var(--gds-text-size-body-m);
+      line-height: var(--gds-text-line-height-body-m);
+    }
+  }
 
   :host([lines]) {
     * {

--- a/libs/core/src/components/content/text/text.style.css.ts
+++ b/libs/core/src/components/content/text/text.style.css.ts
@@ -13,10 +13,14 @@ const style = css`
     text-wrap: inherit;
   }
 
-  :host(:not([size])) {
-    font-size: var(--font-size-body-m);
-    line-height: var(--line-height-body-m);
-  }
+  // TODO: Add defaults for H1-H6 and p
+  // Example:
+  // :host(:not([size])) {
+  // h1 {
+  //   font-size: var(--font-size-body-m);
+  //   line-height: var(--line-height-body-m);
+  // }
+  // }
 
   :host([lines]) {
     * {

--- a/libs/core/src/components/content/text/text.style.css.ts
+++ b/libs/core/src/components/content/text/text.style.css.ts
@@ -7,7 +7,7 @@ const style = css`
 
   * {
     margin: unset;
-    font-weight: normal;
+    font-weight: inherit;
     font-size: inherit;
     line-height: inherit;
     text-wrap: inherit;

--- a/libs/core/src/components/content/text/text.style.css.ts
+++ b/libs/core/src/components/content/text/text.style.css.ts
@@ -67,7 +67,7 @@ const style = css`
 
   :host(:not([weight])) {
     strong {
-      font-weight: var(--gds-text-weight-bold);
+      font-weight: var(--gds-text-weight-book);
     }
   }
 

--- a/libs/core/src/components/content/text/text.style.css.ts
+++ b/libs/core/src/components/content/text/text.style.css.ts
@@ -17,36 +17,57 @@ const style = css`
     h1 {
       font-size: var(--gds-text-size-heading-xl);
       line-height: var(--gds-text-line-height-heading-xl);
+      font-weight: var(--gds-text-weight-regular);
     }
 
     h2 {
       font-size: var(--gds-text-size-heading-l);
       line-height: var(--gds-text-line-height-heading-l);
+      font-weight: var(--gds-text-weight-regular);
     }
 
     h3 {
       font-size: var(--gds-text-size-heading-m);
       line-height: var(--gds-text-line-height-heading-m);
+      font-weight: var(--gds-text-weight-regular);
     }
 
     h4 {
       font-size: var(--gds-text-size-heading-s);
       line-height: var(--gds-text-line-height-heading-s);
+      font-weight: var(--gds-text-weight-regular);
     }
 
     h5 {
       font-size: var(--gds-text-size-heading-xs);
       line-height: var(--gds-text-line-height-heading-xs);
+      font-weight: var(--gds-text-weight-regular);
     }
 
     h6 {
       font-size: var(--gds-text-size-heading-2xs);
       line-height: var(--gds-text-line-height-heading-2xs);
+      font-weight: var(--gds-text-weight-regular);
     }
 
-    p {
+    p,
+    span,
+    em,
+    strong,
+    mark {
       font-size: var(--gds-text-size-body-m);
       line-height: var(--gds-text-line-height-body-m);
+    }
+
+    small {
+      font-size: var(--gds-text-size-detail-xs);
+      line-height: var(--gds-text-line-height-detail-xs);
+    }
+  }
+
+  :host(:not([weight])) {
+    strong {
+      font-weight: var(--gds-text-weight-bold);
     }
   }
 

--- a/libs/core/src/components/content/text/text.style.css.ts
+++ b/libs/core/src/components/content/text/text.style.css.ts
@@ -2,7 +2,7 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    display: block;
+    display: contents;
   }
 
   * {
@@ -11,6 +11,11 @@ const style = css`
     font-size: inherit;
     line-height: inherit;
     text-wrap: inherit;
+  }
+
+  :host(:not([size])) {
+    font-size: var(--font-size-body-m);
+    line-height: var(--line-height-body-m);
   }
 
   :host([lines]) {

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -212,7 +212,8 @@ export class GdsText extends GdsElement {
   color?: string
 
   render() {
-    const TAG = unsafeStatic(this.tag)
+    const TAG_ENCODE = encodeURI(this.tag)
+    const TAG = unsafeStatic(TAG_ENCODE)
     return html`<${TAG} tag><slot></slot></${TAG}>`
   }
 }

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -67,6 +67,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     valueTemplate: (v) => `${v}`,
+    selector: '[tag]',
     styleTemplate: (prop, values) => {
       const size = values[0]
       const styleSize = `font-size: var(--gds-text-size-${size});`
@@ -84,6 +85,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'font-weight',
+    selector: '[tag]',
     valueTemplate: (v) => `var(--gds-text-weight-${v})`,
   })
   weight?: string
@@ -94,7 +96,11 @@ export class GdsText extends GdsElement {
    *
    * @property margin
    */
-  @styleExpressionProperty()
+  @styleExpressionProperty({
+    property: 'margin',
+    selector: '[tag]',
+    valueTemplate: (v) => v,
+  })
   margin?: string
 
   /**
@@ -105,6 +111,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'text-wrap',
+    selector: '[tag]',
     valueTemplate: (v) => v,
   })
   wrap?: string
@@ -117,6 +124,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'text-transform',
+    selector: '[tag]',
     valueTemplate: (v) => v,
   })
   transform?: string
@@ -135,6 +143,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'max-width',
+    selector: '[tag]',
     valueTemplate: (v) => `${v}ch`,
   })
   length?: string
@@ -147,6 +156,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'min-width',
+    selector: '[tag]',
     valueTemplate: (v) => `${v}ch`,
   })
   min?: string
@@ -159,6 +169,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'text-align',
+    selector: '[tag]',
     valueTemplate: (v) => v,
   })
   align?: string
@@ -170,6 +181,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: '--_lines',
+    selector: '[tag]',
     valueTemplate: (v) => v,
   })
   lines?: number
@@ -187,6 +199,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     property: 'color',
+    selector: '[tag]',
     valueTemplate: (v) => {
       const [colorName, transparency] = v.split('/')
       if (transparency) {
@@ -200,6 +213,6 @@ export class GdsText extends GdsElement {
 
   render() {
     const TAG = unsafeStatic(this.tag)
-    return html`<${TAG}><slot></slot></${TAG}>`
+    return html`<${TAG} tag><slot></slot></${TAG}>`
   }
 }

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -1,4 +1,4 @@
-import { html as staticHtml, literal } from 'lit/static-html.js'
+import { html, unsafeStatic } from 'lit/static-html.js'
 import { property } from 'lit/decorators.js'
 import { gdsCustomElement } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
@@ -67,10 +67,11 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     valueTemplate: (v) => `${v}`,
-    selector: (instance) => instance.tag,
     styleTemplate: (prop, values) => {
       const size = values[0]
-      return `font-size: var(--gds-text-size-${size}); line-height: var(--gds-text-line-height-${size});`
+      const styleSize = `font-size: var(--gds-text-size-${size});`
+      const styleLine = `line-height: var(--gds-text-line-height-${size});`
+      return styleSize + styleLine
     },
   })
   size?: string
@@ -198,7 +199,7 @@ export class GdsText extends GdsElement {
   color?: string
 
   render() {
-    const TAG = literal(this.tag)
-    return staticHtml`<${TAG}><slot></slot></${TAG}>`
+    const TAG = unsafeStatic(this.tag)
+    return html`<${TAG}><slot></slot></${TAG}>`
   }
 }

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -39,12 +39,12 @@ export class GdsText extends GdsElement {
    *
    * These are the available values you can use to define size:
    *
-   * `headline-l`,
-   * `headline-m`,
-   * `headline-s`,
-   * `title-l`,
-   * `title-m`,
-   * `title-s`,
+   * `heading-xl`,
+   * `heading-l`,
+   * `heading-m`,
+   * `heading-s`,
+   * `heading-xs`,
+   * `heading-2xs`,
    * `detail-m`,
    * `detail-s`,
    * `detail-xs`,

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -80,6 +80,18 @@ export class GdsText extends GdsElement {
   size?: string
 
   /**
+   * Controls the `font-weight` of the text.
+   * Supports all the weigh tokens.
+   *
+   * @property weight
+   */
+  @styleExpressionProperty({
+    property: 'font-weight',
+    valueTemplate: (v) => `var(--gds-text-weight-${v})`,
+  })
+  weight?: string
+
+  /**
    * Controls the margin of the text.
    * Supports all the default margin values.
    *

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -26,7 +26,7 @@ export class GdsText extends GdsElement {
    * @property tag
    */
   @property({ type: String })
-  tag = 'p'
+  tag = 'span'
 
   /**
    * Controls the size of the text.

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -39,31 +39,34 @@ export class GdsText extends GdsElement {
    *
    * You can apply size like this:
    * ```html
-   * <gds-text size="body-medium"></gds-text>
+   * <gds-text size="body-m"></gds-text>
    * ```
    *
    * These are the available values you can use to define size:
    *
-   * `label-overline`,
-   * `label-input-medium`,
-   * `label-input-large`,
-   * `label-information-medium`,
-   * `label-information-large`,
-   * `label-small`,
-   * `label-medium`,
-   * `label-large`,
-   * `body-small`,
-   * `body-medium`,
-   * `body-large`,
-   * `title-small`,
-   * `title-medium`,
-   * `title-large`,
-   * `headline-small`,
-   * `headline-medium`,
-   * `headline-large`,
-   * `display-small`,
-   * `display-medium`,
-   * `display-large`,
+   * `headline-l`,
+   * `headline-m`,
+   * `headline-s`,
+   * `title-l`,
+   * `title-m`,
+   * `title-s`,
+   * `detail-m`,
+   * `detail-s`,
+   * `detail-xs`,
+   * `body-l`,
+   * `body-m`,
+   * `body-s`,
+   * `display-2xl`,
+   * `display-xl`,
+   * `display-l`,
+   * `display-m`,
+   * `display-s `,
+   * `preamble-2xl`,
+   * `preamble-xl`,
+   * `preamble-l`,
+   * `preamble-m`,
+   * `preamble-s`,
+   * `preamble-xs`,
    *
    * @property size
    */

--- a/libs/core/src/components/content/text/text.ts
+++ b/libs/core/src/components/content/text/text.ts
@@ -1,9 +1,6 @@
-import { css } from 'lit'
+import { html as staticHtml, literal } from 'lit/static-html.js'
 import { property } from 'lit/decorators.js'
-import {
-  gdsCustomElement,
-  html,
-} from '../../../utils/helpers/custom-element-scoping'
+import { gdsCustomElement } from '../../../utils/helpers/custom-element-scoping'
 import { GdsElement } from '../../../gds-element'
 import { tokens } from '../../../tokens.style'
 import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
@@ -20,8 +17,6 @@ import TextCSS from './text.style.css'
  */
 @gdsCustomElement('gds-text')
 export class GdsText extends GdsElement {
-  // static styles = [tokens, TextCSS, ]
-
   static styles = [tokens, TextCSS]
 
   /**
@@ -72,6 +67,7 @@ export class GdsText extends GdsElement {
    */
   @styleExpressionProperty({
     valueTemplate: (v) => `${v}`,
+    selector: (instance) => instance.tag,
     styleTemplate: (prop, values) => {
       const size = values[0]
       return `font-size: var(--gds-text-size-${size}); line-height: var(--gds-text-line-height-${size});`
@@ -177,12 +173,6 @@ export class GdsText extends GdsElement {
   })
   lines?: number
 
-  createTag() {
-    const tag = document.createElement(this.tag)
-    tag.appendChild(document.createElement('slot'))
-    return tag
-  }
-
   /**
    * Controls the color property of the text.
    * Supports all the color tokens from the design system.
@@ -208,6 +198,7 @@ export class GdsText extends GdsElement {
   color?: string
 
   render() {
-    return html`${this.createTag()}`
+    const TAG = literal(this.tag)
+    return staticHtml`<${TAG}><slot></slot></${TAG}>`
   }
 }

--- a/libs/core/src/components/datepicker/datepicker.styles.ts
+++ b/libs/core/src/components/datepicker/datepicker.styles.ts
@@ -38,16 +38,16 @@ export const styles = css`
     }
 
     label {
-      font-size: var(--gds-text-size-label-input-large);
+      font-size: var(--gds-text-size-detail-m);
+      line-height: var(--gds-text-line-height-detail-m);
       font-weight: var(--gds-text-weight-book);
-      line-height: var(--gds-text-line-height-label-input-large);
       font-family: inherit;
     }
 
     .form-info {
-      font-size: var(--gds-text-size-label-information-medium);
+      font-size: var(--gds-text-size-detail-s);
+      line-height: var(--gds-text-line-height-detail-s);
       font-weight: var(--gds-text-weight-regular);
-      line-height: var(--gds-text-line-height-label-information-medium);
     }
 
     .field {
@@ -56,8 +56,8 @@ export const styles = css`
       gap: var(--gds-space-2xs);
       padding: var(--gds-space-2xs);
       border-radius: var(--gds-space-xs);
-      font-size: var(--gds-text-size-label-medium);
-      line-height: var(--gds-text-line-height-label-medium);
+      font-size: var(--gds-text-size-detail-m);
+      line-height: var(--gds-text-line-height-detail-m);
       font-weight: var(--gds-text-weight-regular);
       font-family: inherit;
       overflow: hidden;
@@ -134,7 +134,7 @@ export const styles = css`
 
       &.small {
         height: var(--gds-space-xl);
-        font-size: var(--gds-text-size-label-small);
+        font-size: var(--gds-text-size-detail-s);
         padding: 0;
 
         button {

--- a/libs/core/src/components/datepicker/datepicker.styles.ts
+++ b/libs/core/src/components/datepicker/datepicker.styles.ts
@@ -125,6 +125,7 @@ export const styles = css`
         outline-offset: -4px;
         border-radius: var(--gds-space-xs);
         padding-top: var(--gds-space-3xs);
+        font-family: inherit;
 
         &:focus-visible,
         &:hover {

--- a/libs/core/src/components/dropdown/dropdown.styles.ts
+++ b/libs/core/src/components/dropdown/dropdown.styles.ts
@@ -23,6 +23,7 @@ const style = css`
       cursor: pointer;
       box-sizing: border-box;
       font-size: var(--gds-space-m);
+      font-family: inherit;
 
       // TODO: Update colors to use tokens
       border-color: #6f6f6f;
@@ -89,6 +90,7 @@ const style = css`
       font-weight: var(--gds-text-weight-book);
       flex: 1;
       box-sizing: border-box;
+      font-family: inherit;
 
       &:focus {
         border-color: var(--gds-sys-color-base800);

--- a/libs/core/src/components/dropdown/dropdown.styles.ts
+++ b/libs/core/src/components/dropdown/dropdown.styles.ts
@@ -67,9 +67,9 @@ const style = css`
     }
 
     label {
-      font-weight: var(--gds-text-weight-regular);
-      line-height: var(--gds-text-line-height-label-input-large);
-      font-size: var(--gds-text-size-label-input-large);
+      font-size: var(--gds-text-size-detail-m);
+      line-height: var(--gds-text-line-height-detail-m);
+      font-weight: var(--gds-text-weight-book);
       padding-block: var(--gds-space-2xs);
       font-family: inherit;
     }
@@ -86,7 +86,7 @@ const style = css`
       border-bottom: 1px solid var(--gds-sys-color-base400);
       width: 100%;
       padding: var(--gds-space-m);
-      font-weight: var(--gds-text-weight-regular);
+      font-weight: var(--gds-text-weight-book);
       flex: 1;
       box-sizing: border-box;
 
@@ -97,7 +97,7 @@ const style = css`
       &::placeholder {
         color: currrentColor;
         font-family: inherit;
-        font-weight: var(--gds-text-weight-regular);
+        font-weight: var(--gds-text-weight-book);
         color: var(--gds-sys-color-base800);
       }
     }

--- a/libs/core/src/components/layout/card/card.stories.ts
+++ b/libs/core/src/components/layout/card/card.stories.ts
@@ -382,7 +382,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-m">Base 100</gds-text>
+          <gds-text tag="h3" size="heading-m">Base 100</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -397,7 +397,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-m">Base 200</gds-text>
+          <gds-text tag="h3" size="heading-m">Base 200</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -412,7 +412,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-m">Base 300</gds-text>
+          <gds-text tag="h3" size="heading-m">Base 300</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -427,7 +427,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-m">Base 400</gds-text>
+          <gds-text tag="h3" size="heading-m">Base 400</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -461,7 +461,7 @@ export const CardGrid: Story = {
             padding="s{xs} m{l} l{l}"
             align="flex-start"
           >
-            <gds-text tag="h3" size="l{headline-s} m{headline-s} s{headline-s}">
+            <gds-text tag="h3" size="l{heading-s} m{heading-s} s{heading-s}">
               Sidebar
             </gds-text>
             <gds-text wrap="balance">
@@ -481,7 +481,7 @@ export const CardGrid: Story = {
             justify="center"
             gap="m"
           >
-            <gds-text tag="h3" size="headline-s">
+            <gds-text tag="h3" size="heading-s">
               Span Columns: [2 / -1]</gds-text
             >
             <gds-text>
@@ -507,7 +507,7 @@ export const CardGrid: Story = {
             justify="center"
             gap="m"
           >
-            <gds-text tag="h3" size="headline-s"
+            <gds-text tag="h3" size="heading-s"
               >Span all columns [1 / -1]</gds-text
             >
             <gds-text wrap="balance" lines="3">

--- a/libs/core/src/components/layout/card/card.stories.ts
+++ b/libs/core/src/components/layout/card/card.stories.ts
@@ -72,8 +72,8 @@ export const Card: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-l">James Doe</gds-text>
-              <gds-text>
+              <gds-text tag="h2" size="body-l">James Doe</gds-text>
+              <gds-text tag="p">
                 Passionate software engineer with a love for coding and
                 problem-solving.
               </gds-text>
@@ -107,8 +107,8 @@ export const Card: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-l">Lorem Ipsum</gds-text>
-              <gds-text>
+              <gds-text tag="h2" size="body-l">Lorem Ipsum</gds-text>
+              <gds-text tag="p">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt.
               </gds-text>
@@ -147,8 +147,8 @@ export const Card: Story = {
               height="100%"
             >
               <gds-container>
-                <gds-text size="title-l">Jane Doe</gds-text>
-                <gds-text size="body-m">UX Designer</gds-text>
+                <gds-text tag="h4" size="body-l">Jane Doe</gds-text>
+                <gds-text tag="p" size="body-m">UX Designer</gds-text>
               </gds-container>
               <gds-flex gap="s">
                 <gds-button rank="secondary">Message</gds-button>

--- a/libs/core/src/components/layout/card/card.stories.ts
+++ b/libs/core/src/components/layout/card/card.stories.ts
@@ -72,7 +72,7 @@ export const Card: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-large">James Doe</gds-text>
+              <gds-text tag="h2" size="title-l">James Doe</gds-text>
               <gds-text>
                 Passionate software engineer with a love for coding and
                 problem-solving.
@@ -107,7 +107,7 @@ export const Card: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-large">Lorem Ipsum</gds-text>
+              <gds-text tag="h2" size="title-l">Lorem Ipsum</gds-text>
               <gds-text>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt.
@@ -147,8 +147,8 @@ export const Card: Story = {
               height="100%"
             >
               <gds-container>
-                <gds-text size="title-large">Jane Doe</gds-text>
-                <gds-text size="body-medium">UX Designer</gds-text>
+                <gds-text size="title-l">Jane Doe</gds-text>
+                <gds-text size="body-m">UX Designer</gds-text>
               </gds-container>
               <gds-flex gap="s">
                 <gds-button rank="secondary">Message</gds-button>
@@ -382,7 +382,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-medium">Base 100</gds-text>
+          <gds-text tag="h3" size="headline-m">Base 100</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -397,7 +397,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-medium">Base 200</gds-text>
+          <gds-text tag="h3" size="headline-m">Base 200</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -412,7 +412,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-medium">Base 300</gds-text>
+          <gds-text tag="h3" size="headline-m">Base 300</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -427,7 +427,7 @@ export const CardBackground: Story = {
           direction="column"
           padding="s{xs} m{l} l{l}"
         >
-          <gds-text tag="h3" size="headline-medium">Base 400</gds-text>
+          <gds-text tag="h3" size="headline-m">Base 400</gds-text>
           <gds-text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -461,10 +461,7 @@ export const CardGrid: Story = {
             padding="s{xs} m{l} l{l}"
             align="flex-start"
           >
-            <gds-text
-              tag="h3"
-              size="l{headline-small} m{headline-small} s{headline-small}"
-            >
+            <gds-text tag="h3" size="l{headline-s} m{headline-s} s{headline-s}">
               Sidebar
             </gds-text>
             <gds-text wrap="balance">
@@ -484,14 +481,14 @@ export const CardGrid: Story = {
             justify="center"
             gap="m"
           >
-            <gds-text tag="h3" size="headline-small">
+            <gds-text tag="h3" size="headline-s">
               Span Columns: [2 / -1]</gds-text
             >
             <gds-text>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
               eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </gds-text>
-            <gds-text tag="h2" size="body-medium"
+            <gds-text tag="h2" size="body-m"
               >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
               eiusmod tempor incididunt ut labore et dolore magna aliqua lorem
               ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -510,7 +507,7 @@ export const CardGrid: Story = {
             justify="center"
             gap="m"
           >
-            <gds-text tag="h3" size="headline-small"
+            <gds-text tag="h3" size="headline-s"
               >Span all columns [1 / -1]</gds-text
             >
             <gds-text wrap="balance" lines="3">

--- a/libs/core/src/components/layout/card/card.style.css.ts
+++ b/libs/core/src/components/layout/card/card.style.css.ts
@@ -2,16 +2,6 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    --gds-shadow-xs: 0px 0px 1px 0px rgba(0, 0, 0, 0.1),
-      0px 0px 1px 0px rgba(0, 0, 0, 0.1);
-    --gds-shadow-s: 0px 1px 3px 0px rgba(0, 0, 0, 0.1),
-      0px 1px 2px 0px rgba(0, 0, 0, 0.06);
-    --gds-shadow-m: 0px 4px 8px -2px rgba(0, 0, 0, 0.1),
-      0px 2px 4px -2px rgba(0, 0, 0, 0.06);
-    --gds-shadow-l: 0px 12px 16px -4px rgba(0, 0, 0, 0.08),
-      0px 4px 6px -2px rgba(0, 0, 0, 0.03);
-    --gds-shadow-xl: 0px 20px 24px -4px rgba(0, 0, 0, 0.08),
-      0px 8px 8px -4px rgba(0, 0, 0, 0.03);
     display: block;
   }
 `

--- a/libs/core/src/components/theme/theme.stories.ts
+++ b/libs/core/src/components/theme/theme.stories.ts
@@ -108,7 +108,7 @@ export const Theme: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-l">James Doe</gds-text>
+              <gds-text tag="h2" size="body-l">James Doe</gds-text>
               <gds-text>
                 Passionate software engineer with a love for coding and
                 problem-solving.
@@ -143,7 +143,7 @@ export const Theme: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-l">Lorem Ipsum</gds-text>
+              <gds-text tag="h2" size="body-l">Lorem Ipsum</gds-text>
               <gds-text>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt.
@@ -183,8 +183,8 @@ export const Theme: Story = {
               height="100%"
             >
               <gds-container>
-                <gds-text size="title-l">Jane Doe</gds-text>
-                <gds-text size="body-m">UX Designer</gds-text>
+                <gds-text tag="h4" size="body-l">Jane Doe</gds-text>
+                <gds-text tag="p" size="body-m">UX Designer</gds-text>
               </gds-container>
               <gds-flex gap="s">
                 <gds-button rank="secondary">Message</gds-button>

--- a/libs/core/src/components/theme/theme.stories.ts
+++ b/libs/core/src/components/theme/theme.stories.ts
@@ -108,7 +108,7 @@ export const Theme: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-large">James Doe</gds-text>
+              <gds-text tag="h2" size="title-l">James Doe</gds-text>
               <gds-text>
                 Passionate software engineer with a love for coding and
                 problem-solving.
@@ -143,7 +143,7 @@ export const Theme: Story = {
             gap="l"
           >
             <gds-flex gap="s" direction="column">
-              <gds-text tag="h2" size="title-large">Lorem Ipsum</gds-text>
+              <gds-text tag="h2" size="title-l">Lorem Ipsum</gds-text>
               <gds-text>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt.
@@ -183,8 +183,8 @@ export const Theme: Story = {
               height="100%"
             >
               <gds-container>
-                <gds-text size="title-large">Jane Doe</gds-text>
-                <gds-text size="body-medium">UX Designer</gds-text>
+                <gds-text size="title-l">Jane Doe</gds-text>
+                <gds-text size="body-m">UX Designer</gds-text>
               </gds-container>
               <gds-flex gap="s">
                 <gds-button rank="secondary">Message</gds-button>

--- a/libs/core/src/storybook-docs/style/typography.mdx
+++ b/libs/core/src/storybook-docs/style/typography.mdx
@@ -124,3 +124,27 @@ The scale is based on the place of the text in the hierarchy.
         <gds-text size="preamble-2xl">Preamble 2XL</gds-text>
     </gds-flex>
 </gds-flex>
+
+## Weight
+<gds-flex display="flex" direction="column">
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">bold</gds-text>
+        <gds-text weight="bold">Bold (700)</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">medium</gds-text>
+        <gds-text weight="medium">Medium (500)</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">book</gds-text>
+        <gds-text weight="book">Book (450)</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">regular</gds-text>
+        <gds-text weight="regular">Regular (400)</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">light</gds-text>
+        <gds-text weight="light">Light (300)</gds-text>
+    </gds-flex>
+</gds-flex>

--- a/libs/core/src/storybook-docs/style/typography.mdx
+++ b/libs/core/src/storybook-docs/style/typography.mdx
@@ -23,6 +23,10 @@ The scale is based on the place of the text in the hierarchy.
         <gds-text tag="code" min="30" align="left">headline-l</gds-text>
         <gds-text size="headline-l">Headline Large</gds-text>
     </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">headline-xl</gds-text>
+        <gds-text size="headline-xl">Headline Extra Large</gds-text>
+    </gds-flex>
 </gds-flex>
 
 ## Title

--- a/libs/core/src/storybook-docs/style/typography.mdx
+++ b/libs/core/src/storybook-docs/style/typography.mdx
@@ -9,102 +9,118 @@ import '../../components/content/text/text'
 
 The scale is based on the place of the text in the hierarchy.
 
-## Body
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0"  >
-        <gds-text min="30" align="left">`body-small`</gds-text>
-        <gds-text size="body-small">body-small</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`body-medium`</gds-text>
-        <gds-text size="body-medium">body-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`body-large`</gds-text>
-        <gds-text size="body-large">body-large</gds-text>
-    </gds-flex>
-</gds-flex>
- 
-## Display
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`display-small`</gds-text>
-        <gds-text size="display-small">display-small</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`display-medium`</gds-text>
-        <gds-text size="display-medium">display-medium</gds-text>
-    </gds-flex>
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`display-large`</gds-text>
-        <gds-text size="display-large">display-large</gds-text>
-    </gds-flex>
-</gds-flex>
-
 ## Headline
 <gds-flex display="flex" direction="column">
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`headline-small`</gds-text>
-        <gds-text size="headline-small">headline-small</gds-text>
+        <gds-text tag="code" min="30" align="left">headline-s</gds-text>
+        <gds-text size="headline-s">Headline Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`headline-medium`</gds-text>
-        <gds-text size="headline-medium">headline-medium</gds-text>
+        <gds-text tag="code" min="30" align="left">headline-m</gds-text>
+        <gds-text size="headline-m">Headline Medium</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`headline-large`</gds-text>
-        <gds-text size="headline-large">headline-large</gds-text>
+        <gds-text tag="code" min="30" align="left">headline-l</gds-text>
+        <gds-text size="headline-l">Headline Large</gds-text>
     </gds-flex>
 </gds-flex>
 
 ## Title
 <gds-flex display="flex" direction="column">
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`title-small`</gds-text>
-        <gds-text size="title-small">title-small</gds-text>
+        <gds-text tag="code" min="30" align="left">title-s</gds-text>
+        <gds-text size="title-s">Title Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`title-medium`</gds-text>
-        <gds-text size="title-medium">title-medium</gds-text>
+        <gds-text tag="code" min="30" align="left">title-module={}</gds-text>
+        <gds-text size="title-m">Title Medium</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`title-large`</gds-text>
-        <gds-text size="title-large">title-large</gds-text>
+        <gds-text tag="code" min="30" align="left">title-l</gds-text>
+        <gds-text size="title-l">Title Large</gds-text>
     </gds-flex>
 </gds-flex>
 
-## Label
+## Detail
 <gds-flex display="flex" direction="column">
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-overline`</gds-text>
-        <gds-text size="label-overline">Label Overline</gds-text>
+        <gds-text tag="code" min="30" align="left">detail-xs</gds-text>
+        <gds-text size="detail-xs">Detail Extra Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-input-medium`</gds-text>
-        <gds-text size="label-input-medium">Label Input Medium</gds-text>
+        <gds-text tag="code" min="30" align="left">detail-s</gds-text>
+        <gds-text size="detail-s">Detail Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-input-large`</gds-text>
-        <gds-text size="label-input-large">label-input-large</gds-text>
+        <gds-text tag="code" min="30" align="left">detail-m</gds-text>
+        <gds-text size="detail-m">Detail Medium</gds-text>
+    </gds-flex>
+</gds-flex>
+
+## Body
+<gds-flex display="flex" direction="column">
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">body-s</gds-text>
+        <gds-text size="body-s">Body Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-information-medium`</gds-text>
-        <gds-text size="label-information-medium">label-information-medium</gds-text>
+        <gds-text tag="code" min="30" align="left">body-m</gds-text>
+        <gds-text size="body-m">Body Medium</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-information-large`</gds-text>
-        <gds-text size="label-information-large">label-information-large</gds-text>
+        <gds-text tag="code" min="30" align="left">body-l</gds-text>
+        <gds-text size="body-l">Body Large</gds-text>
+    </gds-flex>
+</gds-flex>
+
+## Display
+<gds-flex display="flex" direction="column">
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">display-s</gds-text>
+        <gds-text size="display-s">Display Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-small`</gds-text>
-        <gds-text size="label-small">label-small</gds-text>
+        <gds-text tag="code" min="30" align="left">display-m</gds-text>
+        <gds-text size="display-m">Display Medium</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-medium`</gds-text>
-        <gds-text size="label-medium">label-medium</gds-text>
+        <gds-text tag="code" min="30" align="left">display-l</gds-text>
+        <gds-text size="display-l">Display Large</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text min="30" align="left">`label-large`</gds-text>
-        <gds-text size="label-large">label-large</gds-text>
+        <gds-text tag="code" min="30" align="left">display-xl</gds-text>
+        <gds-text size="display-xl">Display XL</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">display-2xl</gds-text>
+        <gds-text size="display-2xl">Display 2XL</gds-text>
+    </gds-flex>
+</gds-flex>
+
+## Preamble
+<gds-flex display="flex" direction="column">
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">preamble-xs</gds-text>
+        <gds-text size="preamble-xs">Preamble Extra Small</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">preamble-s</gds-text>
+        <gds-text size="preamble-s">Preamble Small</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">preamble-m</gds-text>
+        <gds-text size="preamble-m">Preamble Medium</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">preamble-l</gds-text>
+        <gds-text size="preamble-l">Preamble Large</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">preamble-xl</gds-text>
+        <gds-text size="preamble-xl">Preamble XL</gds-text>
+    </gds-flex>
+    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
+        <gds-text tag="code" min="30" align="left">preamble-2xl</gds-text>
+        <gds-text size="preamble-2xl">Preamble 2XL</gds-text>
     </gds-flex>
 </gds-flex>

--- a/libs/core/src/storybook-docs/style/typography.mdx
+++ b/libs/core/src/storybook-docs/style/typography.mdx
@@ -9,39 +9,31 @@ import '../../components/content/text/text'
 
 The scale is based on the place of the text in the hierarchy.
 
-## Headline
+## Heading
 <gds-flex display="flex" direction="column">
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">headline-s</gds-text>
-        <gds-text size="headline-s">Headline Small</gds-text>
+        <gds-text tag="code" min="30" align="left">heading-s</gds-text>
+        <gds-text size="heading-2xs">Heading 2XS</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">headline-m</gds-text>
-        <gds-text size="headline-m">Headline Medium</gds-text>
+        <gds-text tag="code" min="30" align="left">heading-s</gds-text>
+        <gds-text size="heading-xs">Heading XS</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">headline-l</gds-text>
-        <gds-text size="headline-l">Headline Large</gds-text>
+        <gds-text tag="code" min="30" align="left">heading-s</gds-text>
+        <gds-text size="heading-s">Heading Small</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">headline-xl</gds-text>
-        <gds-text size="headline-xl">Headline Extra Large</gds-text>
-    </gds-flex>
-</gds-flex>
-
-## Title
-<gds-flex display="flex" direction="column">
-    <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">title-s</gds-text>
-        <gds-text size="title-s">Title Small</gds-text>
+        <gds-text tag="code" min="30" align="left">heading-m</gds-text>
+        <gds-text size="heading-m">Heading Medium</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">title-module={}</gds-text>
-        <gds-text size="title-m">Title Medium</gds-text>
+        <gds-text tag="code" min="30" align="left">heading-l</gds-text>
+        <gds-text size="heading-l">Heading Large</gds-text>
     </gds-flex>
     <gds-flex display="flex" gap="s" padding="l 0" align="center" border="0 0 4xs/base300 0">
-        <gds-text tag="code" min="30" align="left">title-l</gds-text>
-        <gds-text size="title-l">Title Large</gds-text>
+        <gds-text tag="code" min="30" align="left">heading-xl</gds-text>
+        <gds-text size="heading-xl">Heading Extra Large</gds-text>
     </gds-flex>
 </gds-flex>
 

--- a/libs/core/src/tokens.style.ts
+++ b/libs/core/src/tokens.style.ts
@@ -5,6 +5,7 @@ import lightThemeCss from '../../../dist/libs/tokens/internal/theme/light.css?in
 import sizeTokens from '../../../dist/libs/tokens/internal/size.css?inline'
 import textTokens from '../../../dist/libs/tokens/internal/text.css?inline'
 import motionTokens from '../../../dist/libs/tokens/internal/motion.css?inline'
+import shadowTokens from '../../../dist/libs/tokens/internal/shadow.css?inline'
 
 const tokens = [
   unsafeCSS(palletCss),
@@ -12,6 +13,7 @@ const tokens = [
   unsafeCSS(sizeTokens),
   unsafeCSS(textTokens),
   unsafeCSS(motionTokens),
+  unsafeCSS(shadowTokens),
 ]
 
 export { tokens }

--- a/libs/tokens/src/formats.ts
+++ b/libs/tokens/src/formats.ts
@@ -105,6 +105,7 @@ const formats: Record<string, Format> = {
       const dictionary = Object.assign({}, args.dictionary)
       const options = Object.assign({ selector: ':host' }, args.options)
 
+      // TODO: Update all sizes for typography
       // Map each token
       dictionary.allTokens = dictionary.allTokens.map((token) => {
         if (
@@ -219,11 +220,10 @@ const formats: Record<string, Format> = {
   },
   'green/ios-swift-package': {
     name: 'green/ios-swift-package',
-    formatter: function({ options, file }) {
+    formatter: function ({ options, file }) {
       const template = _template(
         fs.readFileSync(
-          process.cwd() +
-            '/libs/tokens/src/templates/ios/spm.package.template',
+          process.cwd() + '/libs/tokens/src/templates/ios/spm.package.template',
         ),
       )
       return template({ file, options, fileHeader })
@@ -286,12 +286,19 @@ const formats: Record<string, Format> = {
         allTokens = [...dictionary.allTokens].sort(sortByName)
       }
       allTokens = useColorScheme(allTokens, options)
-      
+
       let propertyFormatter
       if (options.colorType == 'uiKitDynamicProvider') {
-        propertyFormatter = swift.uiKitColorReferencePropertyFormatter(options.lightModeObjectName, options.darkModeObjectName, options)
+        propertyFormatter = swift.uiKitColorReferencePropertyFormatter(
+          options.lightModeObjectName,
+          options.darkModeObjectName,
+          options,
+        )
       } else if (options.colorType == 'swiftUiReferenceToUiKit') {
-        propertyFormatter = swift.swiftUiColorReferencePropertyFormatter(options.uiKitObjectName, options)
+        propertyFormatter = swift.swiftUiColorReferencePropertyFormatter(
+          options.uiKitObjectName,
+          options,
+        )
       } else {
         const valueFormatter = createPropertyFormatter({
           outputReferences,
@@ -300,10 +307,18 @@ const formats: Record<string, Format> = {
             suffix: '',
           },
         })
-        propertyFormatter = swift.staticPropertyFormatter(options, valueFormatter)
+        propertyFormatter = swift.staticPropertyFormatter(
+          options,
+          valueFormatter,
+        )
       }
       const tree = swift.treeFromTokens(allTokens, options.type)
-      const fileContent = swift.fileContentFromTree(tree, options, file, propertyFormatter)
+      const fileContent = swift.fileContentFromTree(
+        tree,
+        options,
+        file,
+        propertyFormatter,
+      )
       return fileContent
     },
   },

--- a/libs/tokens/src/formats.ts
+++ b/libs/tokens/src/formats.ts
@@ -156,6 +156,73 @@ const formats: Record<string, Format> = {
       )
     },
   },
+  shadow: {
+    name: 'shadow',
+    formatter: function (args) {
+      const dictionary = Object.assign({}, args.dictionary)
+      const options = Object.assign({ selector: ':host' }, args.options)
+
+      // Define opacity values for each shadow size
+      const opacityMap = {
+        xs: [0.1, 0.1],
+        s: [0.1, 0.06],
+        m: [0.1, 0.06],
+        l: [0.08, 0.03],
+        xl: [0.08, 0.03],
+      }
+
+      // Helper function to convert hex to rgba
+      function hexToRgba(hex, opacity) {
+        const bigint = parseInt(hex.slice(1), 16)
+        const r = (bigint >> 16) & 255
+        const g = (bigint >> 8) & 255
+        const b = bigint & 255
+        return `rgba(${r}, ${g}, ${b}, ${opacity})`
+      }
+
+      // Group shadow properties by size
+      const shadowGroups = dictionary.allTokens.reduce((acc, token) => {
+        if (token.path[0] === 'sys' && token.path[1] === 'shadow') {
+          const size = token.path[2].split('-')[0]
+          if (!acc[size]) acc[size] = {}
+          acc[size][token.path.slice(2).join('-')] = token.value
+        }
+        return acc
+      }, {})
+
+      // Create combined shadow variables
+      const combinedShadows = Object.entries(shadowGroups)
+        .map(([size, props]) => {
+          const offsetX1 = props[`${size}-offset-x-1`] || 0
+          const offsetY1 = props[`${size}-offset-y-1`] || 0
+          const blur1 = props[`${size}-blur-1`] || 0
+          const spread1 = props[`${size}-spread-1`] || 0
+          const color1 = hexToRgba(
+            props[`${size}-color-1`] || '#000000',
+            opacityMap[size][0],
+          )
+          const offsetX2 = props[`${size}-offset-x-2`] || 0
+          const offsetY2 = props[`${size}-offset-y-2`] || 0
+          const blur2 = props[`${size}-blur-2`] || 0
+          const spread2 = props[`${size}-spread-2`] || 0
+          const color2 = hexToRgba(
+            props[`${size}-color-2`] || '#000000',
+            opacityMap[size][1],
+          )
+
+          const shadowValue = `${offsetX1}px ${offsetY1}px ${blur1}px ${spread1}px ${color1}, ${offsetX2}px ${offsetY2}px ${blur2}px ${spread2}px ${color2}`
+          return `--gds-shadow-${size}: ${shadowValue};`
+        })
+        .join('\n')
+
+      return (
+        formatHelpers.fileHeader({ file: args.file }) +
+        `${options.selector} {\n` +
+        combinedShadows +
+        `\n}\n`
+      )
+    },
+  },
   'figma/json': {
     name: 'json/figma',
     formatter: function ({ dictionary }) {

--- a/libs/tokens/src/formats.ts
+++ b/libs/tokens/src/formats.ts
@@ -163,6 +163,7 @@ const formats: Record<string, Format> = {
       const options = Object.assign({ selector: ':host' }, args.options)
 
       // Define opacity values for each shadow size
+      // TODO: Implement a better way to handle opacity values or get the colors from Figma tokens
       const opacityMap = {
         xs: [0.1, 0.1],
         s: [0.1, 0.06],

--- a/libs/tokens/src/tokens/shadow/shadow.json
+++ b/libs/tokens/src/tokens/shadow/shadow.json
@@ -1,0 +1,206 @@
+{
+  "sys": {
+    "shadow": {
+      "xs-offset-x-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "xs-offset-y-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "xs-blur-1": {
+        "value": "1",
+        "type": "float"
+      },
+      "xs-spread-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "xs-color-1": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "xs-offset-x-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "xs-offset-y-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "xs-blur-2": {
+        "value": "1",
+        "type": "float"
+      },
+      "xs-spread-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "xs-color-2": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "s-offset-x-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "s-offset-y-1": {
+        "value": "1",
+        "type": "float"
+      },
+      "s-blur-1": {
+        "value": "3",
+        "type": "float"
+      },
+      "s-spread-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "s-color-1": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "s-offset-x-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "s-offset-y-2": {
+        "value": "1",
+        "type": "float"
+      },
+      "s-blur-2": {
+        "value": "2",
+        "type": "float"
+      },
+      "s-spread-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "s-color-2": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "m-offset-x-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "m-offset-y-1": {
+        "value": "4",
+        "type": "float"
+      },
+      "m-blur-1": {
+        "value": "8",
+        "type": "float"
+      },
+      "m-spread-1": {
+        "value": "-2",
+        "type": "float"
+      },
+      "m-color-1": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "m-offset-x-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "m-offset-y-2": {
+        "value": "2",
+        "type": "float"
+      },
+      "m-blur-2": {
+        "value": "4",
+        "type": "float"
+      },
+      "m-spread-2": {
+        "value": "-2",
+        "type": "float"
+      },
+      "m-color-2": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "l-offset-x-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "l-offset-y-1": {
+        "value": "12",
+        "type": "float"
+      },
+      "l-blur-1": {
+        "value": "6",
+        "type": "float"
+      },
+      "l-spread-1": {
+        "value": "-4",
+        "type": "float"
+      },
+      "l-color-1": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "l-offset-x-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "l-offset-y-2": {
+        "value": "4",
+        "type": "float"
+      },
+      "l-blur-2": {
+        "value": "6",
+        "type": "float"
+      },
+      "l-spread-2": {
+        "value": "-2",
+        "type": "float"
+      },
+      "l-color-2": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "xl-offset-x-1": {
+        "value": "0",
+        "type": "float"
+      },
+      "xl-offset-y-1": {
+        "value": "20",
+        "type": "float"
+      },
+      "xl-blur-1": {
+        "value": "24",
+        "type": "float"
+      },
+      "xl-spread-1": {
+        "value": "-4",
+        "type": "float"
+      },
+      "xl-color-1": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "xl-offset-x-2": {
+        "value": "0",
+        "type": "float"
+      },
+      "xl-offset-y-2": {
+        "value": "8",
+        "type": "float"
+      },
+      "xl-blur-2": {
+        "value": "8",
+        "type": "float"
+      },
+      "xl-spread-2": {
+        "value": "-4",
+        "type": "float"
+      },
+      "xl-color-2": {
+        "value": "#000000",
+        "type": "color"
+      }
+    }
+  }
+}

--- a/libs/tokens/src/tokens/shadow/shadow.json
+++ b/libs/tokens/src/tokens/shadow/shadow.json
@@ -130,7 +130,7 @@
         "type": "float"
       },
       "l-blur-1": {
-        "value": "6",
+        "value": "16",
         "type": "float"
       },
       "l-spread-1": {

--- a/libs/tokens/src/tokens/typography/line-height.json
+++ b/libs/tokens/src/tokens/typography/line-height.json
@@ -2,16 +2,20 @@
   "sys": {
     "typography": {
       "line-height": {
-        "headline-l": {
+        "headline-xl": {
           "value": "40",
           "type": "float"
         },
-        "headline-m": {
+        "headline-l": {
           "value": "36",
           "type": "float"
         },
+        "headline-m": {
+          "value": "32",
+          "type": "float"
+        },
         "headline-s": {
-          "value": "30",
+          "value": "28",
           "type": "float"
         },
         "title-l": {

--- a/libs/tokens/src/tokens/typography/line-height.json
+++ b/libs/tokens/src/tokens/typography/line-height.json
@@ -2,31 +2,27 @@
   "sys": {
     "typography": {
       "line-height": {
-        "headline-xl": {
+        "heading-xl": {
+          "value": "44",
+          "type": "float"
+        },
+        "heading-l": {
           "value": "40",
           "type": "float"
         },
-        "headline-l": {
-          "value": "36",
-          "type": "float"
-        },
-        "headline-m": {
+        "heading-m": {
           "value": "32",
           "type": "float"
         },
-        "headline-s": {
+        "heading-s": {
           "value": "28",
           "type": "float"
         },
-        "title-l": {
-          "value": "26",
-          "type": "float"
-        },
-        "title-m": {
+        "heading-xs": {
           "value": "24",
           "type": "float"
         },
-        "title-s": {
+        "heading-2xs": {
           "value": "20",
           "type": "float"
         },

--- a/libs/tokens/src/tokens/typography/line-height.json
+++ b/libs/tokens/src/tokens/typography/line-height.json
@@ -2,84 +2,96 @@
   "sys": {
     "typography": {
       "line-height": {
-        "display-large": {
-          "value": "98",
-          "type": "float"
-        },
-        "display-medium": {
-          "value": "80",
-          "type": "float"
-        },
-        "display-small": {
-          "value": "52",
-          "type": "float"
-        },
-        "headline-large": {
+        "headline-l": {
           "value": "40",
           "type": "float"
         },
-        "headline-medium": {
+        "headline-m": {
           "value": "36",
           "type": "float"
         },
-        "headline-small": {
+        "headline-s": {
           "value": "30",
           "type": "float"
         },
-        "title-large": {
-          "value": "28",
+        "title-l": {
+          "value": "26",
           "type": "float"
         },
-        "title-medium": {
+        "title-m": {
           "value": "24",
           "type": "float"
         },
-        "title-small": {
+        "title-s": {
           "value": "20",
           "type": "float"
         },
-        "body-large": {
+        "detail-m": {
           "value": "20",
           "type": "float"
         },
-        "body-medium": {
-          "value": "20",
-          "type": "float"
-        },
-        "body-small": {
-          "value": "16",
-          "type": "float"
-        },
-        "label-large": {
-          "value": "20",
-          "type": "float"
-        },
-        "label-medium": {
-          "value": "20",
-          "type": "float"
-        },
-        "label-small": {
-          "value": "16",
-          "type": "float"
-        },
-        "label-information-large": {
-          "value": "20",
-          "type": "float"
-        },
-        "label-information-medium": {
-          "value": "20",
-          "type": "float"
-        },
-        "label-input-large": {
-          "value": "20",
-          "type": "float"
-        },
-        "label-input-medium": {
-          "value": "20",
-          "type": "float"
-        },
-        "label-overline": {
+        "detail-s": {
           "value": "18",
+          "type": "float"
+        },
+        "detail-xs": {
+          "value": "16",
+          "type": "float"
+        },
+        "body-l": {
+          "value": "26",
+          "type": "float"
+        },
+        "body-m": {
+          "value": "24",
+          "type": "float"
+        },
+        "body-s": {
+          "value": "20",
+          "type": "float"
+        },
+        "display-2xl": {
+          "value": "90",
+          "type": "float"
+        },
+        "display-xl": {
+          "value": "72",
+          "type": "float"
+        },
+        "display-l": {
+          "value": "56",
+          "type": "float"
+        },
+        "display-m": {
+          "value": "44",
+          "type": "float"
+        },
+        "display-s": {
+          "value": "40",
+          "type": "float"
+        },
+        "preamble-2xl": {
+          "value": "40",
+          "type": "float"
+        },
+        "preamble-xl": {
+          "value": "36",
+          "type": "float"
+        },
+        "preamble-l": {
+          "value": "32",
+          "type": "float"
+        },
+        "preamble-m": {
+          "value": "28",
+          "type": "float"
+        },
+        "preamble-s": {
+          "value": "26",
+          "type": "float"
+        },
+        "preamble-xs": {
+          "value": "24",
           "type": "float"
         }
       }

--- a/libs/tokens/src/tokens/typography/typography.json
+++ b/libs/tokens/src/tokens/typography/typography.json
@@ -2,16 +2,20 @@
   "sys": {
     "typography": {
       "size": {
-        "headline-l": {
+        "headline-xl": {
           "value": "32",
           "type": "float"
         },
-        "headline-m": {
+        "headline-l": {
           "value": "28",
           "type": "float"
         },
-        "headline-s": {
+        "headline-m": {
           "value": "24",
+          "type": "float"
+        },
+        "headline-s": {
+          "value": "20",
           "type": "float"
         },
         "title-l": {

--- a/libs/tokens/src/tokens/typography/typography.json
+++ b/libs/tokens/src/tokens/typography/typography.json
@@ -2,84 +2,96 @@
   "sys": {
     "typography": {
       "size": {
-        "display-large": {
-          "value": "82",
-          "type": "float"
-        },
-        "display-medium": {
-          "value": "64",
-          "type": "float"
-        },
-        "display-small": {
-          "value": "40",
-          "type": "float"
-        },
-        "headline-large": {
+        "headline-l": {
           "value": "32",
           "type": "float"
         },
-        "headline-medium": {
+        "headline-m": {
           "value": "28",
           "type": "float"
         },
-        "headline-small": {
+        "headline-s": {
           "value": "24",
           "type": "float"
         },
-        "title-large": {
-          "value": "22",
+        "title-l": {
+          "value": "20",
           "type": "float"
         },
-        "title-medium": {
+        "title-m": {
           "value": "16",
           "type": "float"
         },
-        "title-small": {
+        "title-s": {
           "value": "14",
           "type": "float"
         },
-        "body-large": {
+        "detail-m": {
           "value": "16",
           "type": "float"
         },
-        "body-medium": {
+        "detail-s": {
           "value": "14",
           "type": "float"
         },
-        "body-small": {
+        "detail-xs": {
           "value": "12",
           "type": "float"
         },
-        "label-large": {
+        "body-l": {
+          "value": "20",
+          "type": "float"
+        },
+        "body-m": {
           "value": "16",
           "type": "float"
         },
-        "label-medium": {
+        "body-s": {
           "value": "14",
           "type": "float"
         },
-        "label-small": {
-          "value": "12",
+        "display-2xl": {
+          "value": "82",
           "type": "float"
         },
-        "label-information-large": {
+        "display-xl": {
+          "value": "64",
+          "type": "float"
+        },
+        "display-l": {
+          "value": "48",
+          "type": "float"
+        },
+        "display-m": {
+          "value": "36",
+          "type": "float"
+        },
+        "display-s": {
+          "value": "32",
+          "type": "float"
+        },
+        "preamble-2xl": {
+          "value": "32",
+          "type": "float"
+        },
+        "preamble-xl": {
+          "value": "28",
+          "type": "float"
+        },
+        "preamble-l": {
+          "value": "24",
+          "type": "float"
+        },
+        "preamble-m": {
+          "value": "20",
+          "type": "float"
+        },
+        "preamble-s": {
+          "value": "18",
+          "type": "float"
+        },
+        "preamble-xs": {
           "value": "16",
-          "type": "float"
-        },
-        "label-information-medium": {
-          "value": "14",
-          "type": "float"
-        },
-        "label-input-large": {
-          "value": "16",
-          "type": "float"
-        },
-        "label-input-medium": {
-          "value": "14",
-          "type": "float"
-        },
-        "label-overline": {
-          "value": "14",
           "type": "float"
         }
       }

--- a/libs/tokens/src/tokens/typography/typography.json
+++ b/libs/tokens/src/tokens/typography/typography.json
@@ -2,31 +2,27 @@
   "sys": {
     "typography": {
       "size": {
-        "headline-xl": {
+        "heading-xl": {
           "value": "32",
           "type": "float"
         },
-        "headline-l": {
+        "heading-l": {
           "value": "28",
           "type": "float"
         },
-        "headline-m": {
+        "heading-m": {
           "value": "24",
           "type": "float"
         },
-        "headline-s": {
+        "heading-s": {
           "value": "20",
           "type": "float"
         },
-        "title-l": {
-          "value": "20",
-          "type": "float"
-        },
-        "title-m": {
+        "heading-xs": {
           "value": "16",
           "type": "float"
         },
-        "title-s": {
+        "heading-2xl": {
           "value": "14",
           "type": "float"
         },

--- a/libs/tokens/style-dictionary.config.ts
+++ b/libs/tokens/style-dictionary.config.ts
@@ -107,6 +107,16 @@ const config: StyleDictionary.Config = {
           },
         },
         {
+          destination: 'shadow.css',
+          format: 'shadow',
+          filter: function (token) {
+            return token.path.includes('shadow')
+          },
+          options: {
+            outputReferences: true,
+          },
+        },
+        {
           destination: 'motion.css',
           format: 'css/variables',
           filter: 'isMotion',
@@ -401,7 +411,7 @@ const config: StyleDictionary.Config = {
             platformVersion: '15',
             targets: [swiftPackageName],
             resources: ['Assets'],
-          }
+          },
         },
         {
           destination: swiftSourcePath + 'Colors/LightModeColors.swift',
@@ -434,10 +444,10 @@ const config: StyleDictionary.Config = {
           options: {
             type: 'color',
             colorType: 'uiKitDynamicProvider',
-            import: ["UIKit"],
+            import: ['UIKit'],
             lightModeObjectName: 'LightModeColors',
             darkModeObjectName: 'DarkModeColors',
-          }
+          },
         },
         {
           destination: swiftSourcePath + '/Colors/Colors.swift',
@@ -448,9 +458,9 @@ const config: StyleDictionary.Config = {
           options: {
             type: 'color',
             colorType: 'swiftUiReferenceToUiKit',
-            import: ["SwiftUI"],
+            import: ['SwiftUI'],
             uiKitObjectName: 'UIColors',
-          }
+          },
         },
         {
           destination: swiftSourcePath + 'Dimensions.swift',
@@ -459,8 +469,8 @@ const config: StyleDictionary.Config = {
           className: 'Dimensions',
           packageName: swiftPackageName,
           options: {
-            type: 'sys'
-          }
+            type: 'sys',
+          },
         },
         {
           destination: swiftSourcePath + 'Radii.swift',
@@ -469,8 +479,8 @@ const config: StyleDictionary.Config = {
           className: 'Radii',
           packageName: swiftPackageName,
           options: {
-            type: 'sys'
-          }
+            type: 'sys',
+          },
         },
       ],
     },


### PR DESCRIPTION
This PR updates all the typography tokens, the typography style story and all the components that have used the `gds-text` component. 

Also the typography scale is refactored and `title` sizes are removed in favor of `heading` scale to match `h1-h6` with `heading-xl` - `heading-2xs` respectively. 

- [x]  Fixes: #1542 
- [x] Fixes: seb-oss/green/issues/1531

Some improvements also has been done on the `gds-text` component by applying all the styling directly to the tag, better defaults and the way how the tag is created. 

This change depreciates the following typography tokens:

| Deprecated Sizes                                   |
|----------------------------------------------------|
| label-overline                                      |
| label-input-medium                                  |
| label-input-large                                   |
| label-information-medium                            |
| label-information-large                             |
| label-small                                        |
| label-medium                                       |
| label-large                                        |
| body-small                                         |
| body-medium                                        |
| body-large                                         |
| title-small                                        |
| title-medium                                       |
| title-large                                        |
| headline-small                                     |
| headline-medium                                    |
| headline-large                                     |

| New Sizes                     |
|--------------------------------|
| heading-xl                     |
| heading-l                      |
| heading-m                      |
| heading-s                      |
| heading-xs                     |
| heading-2xs                    |
| detail-m                       |
| detail-s                       |
| detail-xs                      |
| body-l                         |
| body-m                         |
| body-s                         |
| display-2xl                    |
| display-xl                     |
| display-l                      |
| display-m                      |
| display-s                      |
| preamble-2xl                  |
| preamble-xl                   |
| preamble-l                    |
| preamble-m                    |
| preamble-s                    |
| preamble-xs                   |

