### PR TITLE
refactor/inaccurate-accordion-chevron-icon

### DIFF
--- a/.changeset/witty-rockets-mix.md
+++ b/.changeset/witty-rockets-mix.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/chlorophyll": patch
+---
+
+Change stroke to path fill on chevron icon

--- a/libs/chlorophyll/scss/components/accordion/_mixins.scss
+++ b/libs/chlorophyll/scss/components/accordion/_mixins.scss
@@ -55,7 +55,9 @@
         top: 1rem;
         right: 1rem;
         transition: transform tokens.$transition-time;
-        stroke: currentColor;
+        path {
+          fill: currentColor;
+        }
       }
 
       &:not([aria-expanded='true']):hover {


### PR DESCRIPTION
Design lib:

![image](https://github.com/user-attachments/assets/7c887256-27ae-4dba-a15d-68f7797a13d1)

Green chlorophyll:

![image](https://github.com/user-attachments/assets/0623b4b8-84c9-4845-a7e6-f514710bc423)

Fix:
![image](https://github.com/user-attachments/assets/6931bcd1-68d1-4af4-a3e3-a529e9326820)
