### PR TITLE
Menu button: Expose CSSPart for main slot

### DIFF
--- a/.changeset/four-beds-accept.md
+++ b/.changeset/four-beds-accept.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Menu button:** Expose CSSPart for main slot

--- a/libs/core/src/components/menu-button/menu-button.ts
+++ b/libs/core/src/components/menu-button/menu-button.ts
@@ -19,6 +19,8 @@ import style from './menu-button.css?inline'
  * @slot trail - An optional slot that allows a `gds-icon` element to be placed after the label.
  *
  * @event click - Fired when the button is clicked.
+ *
+ * @csspart main-slot - The main slot of the button, between the lead and trail slots.
  */
 @gdsCustomElement('gds-menu-button')
 export class MenuButton extends GdsElement {

--- a/libs/core/src/components/menu-button/menu-button.ts
+++ b/libs/core/src/components/menu-button/menu-button.ts
@@ -102,7 +102,7 @@ export class MenuButton extends GdsElement {
         download=${ifDefined(this.#isLink ? this.download : undefined)}
       >
         <slot name="lead"></slot>
-        <slot></slot>
+        <slot part="main-slot"></slot>
         <slot name="trail"></slot>
       </${tag}>
     `


### PR DESCRIPTION
There was a request to be able to customize text-alignment of the menu button. Usually, this can be done by styling the slotted element, but in the menu button the slot itself needs some default styles which sets it to `display: inline-block`.

This PR adds a CSSPart hook for the main slot so that it can be customized.