### PR TITLE
Fix calendar jumping when changing months 

### DIFF
--- a/.changeset/gentle-days-clap.md
+++ b/.changeset/gentle-days-clap.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Calendar:** Fix jumping height when changing months. Fixes #1441

--- a/apps/core-lib-dev/src/app/calendar.element.ts
+++ b/apps/core-lib-dev/src/app/calendar.element.ts
@@ -4,6 +4,8 @@ import { html } from '@sebgroup/green-core/scoping'
 
 import '@sebgroup/green-core/components/calendar/index.js'
 
+const YEAR_MONTH = `${new Date().getFullYear()}-${new Date().getMonth() + 1}`
+
 @customElement('calendar-example')
 export class CalendarExample extends LitElement {
   protected createRenderRoot() {
@@ -25,22 +27,22 @@ export class CalendarExample extends LitElement {
 
   #customizedDates = [
     {
-      date: new Date('2024-06-12'),
+      date: new Date(`${YEAR_MONTH}-07`),
       indicator: 'dot',
       color: 'var(--intent-danger-background)',
     },
     {
-      date: new Date('2024-06-13'),
+      date: new Date(`${YEAR_MONTH}-12`),
       indicator: 'dot',
       color: 'var(--intent-danger-background)',
     },
     {
-      date: new Date('2024-06-24'),
+      date: new Date(`${YEAR_MONTH}-24`),
       indicator: 'dot',
       color: 'var(--intent-danger-background)',
     },
     {
-      date: new Date('2024-06-07'),
+      date: new Date(`${YEAR_MONTH}-21`),
       indicator: 'dot',
       disabled: true,
     },

--- a/libs/core/src/components/calendar/calendar.styles.ts
+++ b/libs/core/src/components/calendar/calendar.styles.ts
@@ -31,8 +31,8 @@ const style = css`
     tbody {
       td {
         position: relative;
-        height: var(--gds-space-2xl);
-        width: var(--gds-space-2xl);
+        height: var(--gds-space-3xl);
+        width: var(--gds-space-3xl);
         box-sizing: border-box;
         text-align: center;
         user-select: none;

--- a/libs/core/src/components/calendar/calendar.trans.styles.scss
+++ b/libs/core/src/components/calendar/calendar.trans.styles.scss
@@ -6,11 +6,16 @@
   @layer _base {
     :host {
       @include mixins.calendar();
-    }
 
-    table {
-      flex-grow: 1;
-      width: 100%;
+      table {
+        flex-grow: 1;
+        width: 100%;
+      }
+
+      table td {
+        width: 3rem;
+        height: 3rem;
+      }
     }
   }
 

--- a/libs/core/src/components/calendar/functions.ts
+++ b/libs/core/src/components/calendar/functions.ts
@@ -22,6 +22,11 @@ export function renderMonthGridView(
     { weekStartsOn: 1 },
   )
 
+  // pad `weeks` so that we always render 6 rows
+  while (weeks.length < 6) {
+    weeks.push(addDays(weeks[weeks.length - 1], 7))
+  }
+
   return html`${template(
     weeks.map((weekStartDay) => ({
       days: eachDayOfInterval({


### PR DESCRIPTION
This PR sets the minimum number of week rows to 6, even for months only spanning over 5 weeks. This prevents height in the calendar from changing while stepping through months. Solution for #1441