### PR TITLE
Add support for pseudo-selectors in Style Expression Properties

### DIFF
--- a/.changeset/wicked-rules-camp.md
+++ b/.changeset/wicked-rules-camp.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': minor
+---
+
+**Declarative Layout:** Add support for pseudo sub-selectors, like `:hover`, ':focus', etc.

--- a/libs/core/src/storybook-docs/concepts/declarative-layout.mdx
+++ b/libs/core/src/storybook-docs/concepts/declarative-layout.mdx
@@ -82,8 +82,17 @@ a CSS variable. For example: `padding="xs; l {m xl m xl}"`
 When no media query is specified, it is the same as setting the breakpoint to 0. So, `padding="0 {m}"` is equivalent
 to `padding="m"`.
 
-Semicolon `;` is used to separate media queries, but is only mandatory when the shorthand 0 breakpoint is used, as
-in the first example above.
+### Pseudo selectors
+
+Psudeo selectors can be added to any media query as a separate value sequence. For example:
+
+```html
+<gds-container padding="xs; hover: s; l { s; hover: m }">
+  <!-- Any HTML element can go as children -->
+</gds-container>
+```
+
+In the above example, the padding will be `xs` by default, `s` on hover, `m` in `l` viewports, and `m` on hover in `l` viewports.
 
 For more examples, see the stories under Components/Layout.
 

--- a/libs/core/src/utils/decorators/style-expression-property.ts
+++ b/libs/core/src/utils/decorators/style-expression-property.ts
@@ -13,7 +13,7 @@ export type StyleExpressionPropertyOptions = {
 }
 
 /**
- * Property decorator for creating style expression properties.
+ * todo
  */
 export function styleExpressionProperty(
   options?: StyleExpressionPropertyOptions,
@@ -28,36 +28,20 @@ export function styleExpressionProperty(
       options?.valueTemplate ?? ((v) => `var(--gds-space-${v})`)
     const styleTemplate = options?.styleTemplate
 
-    const states = [null, 'hover', 'focus-within']
+    // Jack into Lits property decorator
+    property({ attribute: options?.attribute })(proto, descriptor)
 
-    states.forEach((state) => {
-      const d = state ? `${state}:${String(descriptor)}` : String(descriptor)
-
-      // Jack into Lits property decorator
-      property({
-        attribute:
-          options?.attribute && `${state}:${String(options.attribute)}`,
-      })(proto, d)
-
-      // And also our own watch decorator to catch changes
-      watch(d)(proto, d, {
-        value: function (oldValue: unknown, newValue: unknown) {
-          const ast = parse(tokenize(newValue as string))
-          const css = toCss(
-            state ? sel + `(:${state})` : sel,
-            prop,
-            ast,
-            valueTemplate,
-            styleTemplate,
-          )
-          console.log('watch', d, css)
-          ;(this as any)[`__${d}_ast`] = ast
-          ;(this as GdsElement)._dynamicStylesController.inject(
-            `sep_${d}`,
-            unsafeCSS(css),
-          )
-        },
-      })
+    // And also our own watch decorator to catch changes
+    watch(descriptor as string)(proto, descriptor as string, {
+      value: function (oldValue: unknown, newValue: unknown) {
+        const ast = parse(tokenize(newValue as string))
+        const css = toCss(sel, prop, ast, valueTemplate, styleTemplate)
+        ;(this as any)[`__${String(descriptor)}_ast`] = ast
+        ;(this as GdsElement)._dynamicStylesController.inject(
+          `sep_${String(descriptor)}`,
+          unsafeCSS(css),
+        )
+      },
     })
   }
 }

--- a/libs/core/src/utils/decorators/style-expression-property.ts
+++ b/libs/core/src/utils/decorators/style-expression-property.ts
@@ -4,16 +4,35 @@ import { GdsElement } from 'src/gds-element'
 import { watch } from './watch'
 import { tokenize, parse, toCss } from '../helpers/style-expression-parser'
 
+/**
+ * Options for `@styleExpressionProperty`.
+ */
 export type StyleExpressionPropertyOptions = {
+  /** The DOM-attribute to bind to. Same as the attribute option on Lits @property decorator */
   attribute?: string
+
+  /** The selector to use for the CSS rule. Defaults to `:host` */
   selector?: string
+
+  /** The CSS property to set. Defaults to the property key, i.e if the decorator is
+   * attached to a property named `padding`, the default name of the CSS property will
+   * also be `padding`. This option overrides that. */
   property?: string
+
+  /** A function that takes a value and returns a string. Defaults to `(value) => 'var(--gds-space-${value})'`
+   * This can be used to resolve the values into CSS variables for example. */
   valueTemplate?: (value: string) => string
+
+  /** A function that takes a property name and an array of values and returns a string. Defaults to
+   * `(property, values) => `${property}: ${values.join(' ')};`
+   * This can be used to customize the generated CSS. This runs after the `valueTemplate` is executed. */
   styleTemplate?: (property: string, values: string[]) => string
 }
 
 /**
- * todo
+ * A decorator that can be used to create a Style Expression Property.
+ *
+ * @param options Options for the decorator.
  */
 export function styleExpressionProperty(
   options?: StyleExpressionPropertyOptions,

--- a/libs/core/src/utils/decorators/style-expression-property.ts
+++ b/libs/core/src/utils/decorators/style-expression-property.ts
@@ -13,7 +13,7 @@ export type StyleExpressionPropertyOptions = {
 }
 
 /**
- * todo
+ * Property decorator for creating style expression properties.
  */
 export function styleExpressionProperty(
   options?: StyleExpressionPropertyOptions,
@@ -28,20 +28,36 @@ export function styleExpressionProperty(
       options?.valueTemplate ?? ((v) => `var(--gds-space-${v})`)
     const styleTemplate = options?.styleTemplate
 
-    // Jack into Lits property decorator
-    property({ attribute: options?.attribute })(proto, descriptor)
+    const states = [null, 'hover', 'focus-within']
 
-    // And also our own watch decorator to catch changes
-    watch(descriptor as string)(proto, descriptor as string, {
-      value: function (oldValue: unknown, newValue: unknown) {
-        const ast = parse(tokenize(newValue as string))
-        const css = toCss(sel, prop, ast, valueTemplate, styleTemplate)
-        ;(this as any)[`__${String(descriptor)}_ast`] = ast
-        ;(this as GdsElement)._dynamicStylesController.inject(
-          `sep_${String(descriptor)}`,
-          unsafeCSS(css),
-        )
-      },
+    states.forEach((state) => {
+      const d = state ? `${state}:${String(descriptor)}` : String(descriptor)
+
+      // Jack into Lits property decorator
+      property({
+        attribute:
+          options?.attribute && `${state}:${String(options.attribute)}`,
+      })(proto, d)
+
+      // And also our own watch decorator to catch changes
+      watch(d)(proto, d, {
+        value: function (oldValue: unknown, newValue: unknown) {
+          const ast = parse(tokenize(newValue as string))
+          const css = toCss(
+            state ? sel + `(:${state})` : sel,
+            prop,
+            ast,
+            valueTemplate,
+            styleTemplate,
+          )
+          console.log('watch', d, css)
+          ;(this as any)[`__${d}_ast`] = ast
+          ;(this as GdsElement)._dynamicStylesController.inject(
+            `sep_${d}`,
+            unsafeCSS(css),
+          )
+        },
+      })
     })
   }
 }

--- a/libs/core/src/utils/helpers/style-expression-parser-tester.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser-tester.ts
@@ -8,7 +8,7 @@ import { tokenize, parse, toCss } from './style-expression-parser'
 
 const expression = 'block; hover:flex; xl { focus:block; flex }'
 const ast = parse(tokenize(expression))
-const css = toCss('div', 'padding', ast)
+const css = toCss(':host', 'background', ast)
 console.log(
   'AST',
   inspect(ast, { showHidden: false, depth: null, colors: true }),

--- a/libs/core/src/utils/helpers/style-expression-parser-tester.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser-tester.ts
@@ -1,0 +1,16 @@
+// This file is here to help with development of the style expression parser, since the regular
+// tests are a bit clunky for this kind of work.
+//
+// Run it like this: `npx tsx libs/core/src/utils/helpers/style-expression-parser-tester.ts`
+
+import { inspect } from 'util'
+import { tokenize, parse, toCss } from './style-expression-parser'
+
+const expression = 'block; hover:flex; xl { focus:block; flex }'
+const ast = parse(tokenize(expression))
+const css = toCss('div', 'padding', ast)
+console.log(
+  'AST',
+  inspect(ast, { showHidden: false, depth: null, colors: true }),
+)
+console.log(inspect(css, { showHidden: false, depth: null, colors: true }))

--- a/libs/core/src/utils/helpers/style-expression-parser.test.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser.test.ts
@@ -133,7 +133,7 @@ describe('style-expression-parser', () => {
       '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-xl) var(--gds-sys-space-s) var(--gds-sys-space-m) var(--gds-sys-space-2xl);}}',
       '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-xl);}}@media (min-width: 2560px) {.test{padding: var(--gds-sys-space-l);}}',
       '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-xl);}}@media (min-width: 512px) and (max-width: 1024px) {.test{padding: var(--gds-sys-space-s) var(--gds-sys-space-m);}}',
-      '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-l);}.test:hover{padding: var(--gds-sys-space-xl);}}@media (min-width: 1440px) {.test{padding: var(--gds-sys-space-xl);}.test:hover{padding: var(--gds-sys-space-2xl);}.test:focus{padding: var(--gds-sys-space-3xl);}}',
+      '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-l);}@media (hover: hover) {.test:hover{padding: var(--gds-sys-space-xl);}}}@media (min-width: 1440px) {.test{padding: var(--gds-sys-space-xl);}@media (hover: hover) {.test:hover{padding: var(--gds-sys-space-2xl);}}.test:focus{padding: var(--gds-sys-space-3xl);}}',
     ]
 
     expressions.forEach((expression, i) => {

--- a/libs/core/src/utils/helpers/style-expression-parser.test.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser.test.ts
@@ -12,6 +12,8 @@ describe('style-expression-parser', () => {
       'xl; >=s, <=xl { s m }',
       'flex',
       'block; xl { flex }',
+      'block; hover:flex; xl { flex; hover:block }',
+      'xs xs xs xs; l { s s s s; hover: m m m m }',
     ]
     const expected = [
       ['xl'],
@@ -22,6 +24,10 @@ describe('style-expression-parser', () => {
       ['xl', ';', '>=s', ',', '<=xl', '{', 's', 'm', '}'],
       ['flex'],
       ['block', ';', 'xl', '{', 'flex', '}'],
+      // prettier-ignore
+      ['block', ';', 'hover', ':', 'flex', ';', 'xl', '{', 'flex', ';', 'hover', ':', 'block', '}'],
+      // prettier-ignore
+      ['xs', 'xs', 'xs', 'xs', ';', 'l', '{', 's', 's', 's', 's', ';', 'hover', ':', 'm', 'm', 'm', 'm', '}'],
     ]
 
     expressions.forEach((expression, i) => {
@@ -41,37 +47,70 @@ describe('style-expression-parser', () => {
       'xl; >=512px, <=1024px { s m }',
       '5',
       '5; xl { 2-7 }',
+      'block; hover:flex; xl { focus:block; flex }',
     ]
 
     const expected = [
-      [{ breakpoint: '-', values: ['xl'] }],
-      [{ breakpoint: '-', values: ['xl', 's', 'm', '2xl'] }],
+      [{ breakpoint: '-', values: [{ sel: '', values: ['xl'] }] }],
       [
-        { breakpoint: '-', values: ['xl'] },
-        { breakpoint: '2xl', values: ['l'] },
-      ],
-      [{ breakpoint: '2xl', values: ['l', 'm', 'm', 'l'] }],
-      [
-        { breakpoint: '-', values: ['xl', 's', 's', 'm'] },
-        { breakpoint: '>s,<xl', values: ['s', 'm'] },
+        {
+          breakpoint: '-',
+          values: [{ sel: '', values: ['xl', 's', 'm', '2xl'] }],
+        },
       ],
       [
-        { breakpoint: '-', values: ['xl'] },
-        { breakpoint: '>=s,<=xl', values: ['s', 'm'] },
+        { breakpoint: '-', values: [{ sel: '', values: ['xl'] }] },
+        { breakpoint: '2xl', values: [{ sel: '', values: ['l'] }] },
       ],
       [
-        { breakpoint: '-', values: ['xl'] },
-        { breakpoint: '>=s,<=xl', values: ['s', 'm'] },
-        { breakpoint: '2xl', values: ['l'] },
+        {
+          breakpoint: '2xl',
+          values: [{ sel: '', values: ['l', 'm', 'm', 'l'] }],
+        },
       ],
       [
-        { breakpoint: '-', values: ['xl'] },
-        { breakpoint: '>=512px,<=1024px', values: ['s', 'm'] },
+        {
+          breakpoint: '-',
+          values: [{ sel: '', values: ['xl', 's', 's', 'm'] }],
+        },
+        { breakpoint: '>s,<xl', values: [{ sel: '', values: ['s', 'm'] }] },
       ],
-      [{ breakpoint: '-', values: ['5'] }],
       [
-        { breakpoint: '-', values: ['5'] },
-        { breakpoint: 'xl', values: ['2-7'] },
+        { breakpoint: '-', values: [{ sel: '', values: ['xl'] }] },
+        { breakpoint: '>=s,<=xl', values: [{ sel: '', values: ['s', 'm'] }] },
+      ],
+      [
+        { breakpoint: '-', values: [{ sel: '', values: ['xl'] }] },
+        { breakpoint: '>=s,<=xl', values: [{ sel: '', values: ['s', 'm'] }] },
+        { breakpoint: '2xl', values: [{ sel: '', values: ['l'] }] },
+      ],
+      [
+        { breakpoint: '-', values: [{ sel: '', values: ['xl'] }] },
+        {
+          breakpoint: '>=512px,<=1024px',
+          values: [{ sel: '', values: ['s', 'm'] }],
+        },
+      ],
+      [{ breakpoint: '-', values: [{ sel: '', values: ['5'] }] }],
+      [
+        { breakpoint: '-', values: [{ sel: '', values: ['5'] }] },
+        { breakpoint: 'xl', values: [{ sel: '', values: ['2-7'] }] },
+      ],
+      [
+        {
+          breakpoint: '-',
+          values: [
+            { sel: '', values: ['block'] },
+            { sel: 'hover', values: ['flex'] },
+          ],
+        },
+        {
+          breakpoint: 'xl',
+          values: [
+            { sel: 'focus', values: ['block'] },
+            { sel: '', values: ['flex'] },
+          ],
+        },
       ],
     ]
 
@@ -86,6 +125,7 @@ describe('style-expression-parser', () => {
       'xl s m 2xl',
       'xl; 2xl { l }',
       'xl; >=512px, <=1024px { s m }',
+      'l; hover:xl; xl { xl; hover:2xl; focus:3xl }',
     ]
 
     const expected = [
@@ -93,6 +133,7 @@ describe('style-expression-parser', () => {
       '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-xl) var(--gds-sys-space-s) var(--gds-sys-space-m) var(--gds-sys-space-2xl);}}',
       '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-xl);}}@media (min-width: 2560px) {.test{padding: var(--gds-sys-space-l);}}',
       '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-xl);}}@media (min-width: 512px) and (max-width: 1024px) {.test{padding: var(--gds-sys-space-s) var(--gds-sys-space-m);}}',
+      '@media (min-width: 0px) {.test{padding: var(--gds-sys-space-l);}.test:hover{padding: var(--gds-sys-space-xl);}}@media (min-width: 1440px) {.test{padding: var(--gds-sys-space-xl);}.test:hover{padding: var(--gds-sys-space-2xl);}.test:focus{padding: var(--gds-sys-space-3xl);}}',
     ]
 
     expressions.forEach((expression, i) => {

--- a/libs/core/src/utils/helpers/style-expression-parser.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser.ts
@@ -1,6 +1,9 @@
+import { tr } from 'date-fns/locale'
+
 type Tokens = string[]
 type BreakpointSpecifier = { condition: string; value: string }[]
-type BreakpointData = { breakpoint: string; values: string[] }
+type BreakpointValues = { sel: string; values: string[] }
+type BreakpointData = { breakpoint: string; values: BreakpointValues[] }
 type BreakpointTree = BreakpointData[]
 
 const viewportBreakpoints: Record<string, string> = {
@@ -20,7 +23,7 @@ const viewportBreakpoints: Record<string, string> = {
 
 const breakpointValueRegex = /^([<|>]=?)?([0-9a-z]+)/
 
-const singleCharTokens = ['{', '}', ';', ',']
+const controlTokens = ['{', '}', ';', ':', ',']
 const whitespace = [' ', '/n']
 
 /**
@@ -38,7 +41,7 @@ export function tokenize(source: string): Tokens {
 
     if (!whitespace.includes(c)) scanned += c
 
-    if (singleCharTokens.includes(c)) {
+    if (controlTokens.includes(c)) {
       lexemes.push(scanned.slice(0, -1))
       lexemes.push(c)
       scanned = ''
@@ -62,60 +65,70 @@ export function tokenize(source: string): Tokens {
  * @returns A tree structure
  */
 export function parse(tokens: Tokens): BreakpointTree {
-  const tree = []
-  let level = 'bp'
-  let scope: BreakpointData | undefined = undefined
-  let expectMultiCondition = false
+  // This is the tree we are building and returning at the end
+  const tree: BreakpointTree = []
 
+  // The current breakpoint scope we are adding to
+  let bpScope: BreakpointData = { breakpoint: '-', values: [] }
+
+  // A function to create an empty breakpoint value bucket
+  const getEmptyBucket = (): BreakpointValues => ({ sel: '', values: [] })
+
+  // The current value bucket we are adding to
+  let valueBucket: BreakpointValues = getEmptyBucket()
+
+  // Step through the tokens
   for (const t of tokens) {
-    if (!singleCharTokens.includes(t)) {
-      if (level === 'val' && scope) {
-        t !== '}' && scope.values.push(t)
-      } else {
-        if (scope && expectMultiCondition) {
-          scope.breakpoint += `,${t}`
-          expectMultiCondition = false
-          continue
-        }
-        if (!scope) {
-          scope = { breakpoint: t, values: [] }
-          tree.push(scope)
-        } else {
-          // This means short hand 0 breakpoint
-          level = 'val'
-          scope.values.push(scope.breakpoint)
-          scope.values.push(t)
-          scope.breakpoint = '-'
-        }
-      }
+    // Add non-control tokens to the value bucket
+    if (!controlTokens.includes(t)) {
+      valueBucket.values.push(t)
       continue
     }
 
-    if (t === ',') {
-      expectMultiCondition = true
-      continue
-    }
-
+    // If we come across '{', then create a new breakpoint scope, and empty the
+    // value bucket into the breakpoint specifier
     if (t === '{') {
-      level = 'val'
-      continue
+      bpScope = { breakpoint: valueBucket.values.join(','), values: [] }
+      valueBucket = getEmptyBucket()
     }
 
-    if (t === '}' || t === ';') {
-      level = 'bp'
-      scope = undefined
-      continue
+    // If we come across ';', then empty the value bucket into the breakpoint scope
+    // And if the tree is still empty at this point, we add the breakpoint scope to the tree
+    if (t === ';') {
+      if (tree.length === 0) {
+        tree.push(bpScope)
+      }
+      if (valueBucket.values.length > 0) {
+        bpScope.values.push(valueBucket)
+        valueBucket = getEmptyBucket()
+      }
+    }
+
+    // If we come across ':', then pop the last value from the value bucket and use
+    // it as the selector for a new value bucket
+    if (t === ':') {
+      const sel = valueBucket.values.pop() ?? ''
+      valueBucket.sel = sel
+    }
+
+    // If we come across '}', then close the breakpoint scope and add it to the tree
+    if (bpScope && t === '}') {
+      bpScope.values.push(valueBucket)
+      valueBucket = getEmptyBucket()
+      tree.push(bpScope)
     }
   }
 
-  return tree.map((bp) => {
-    // Fix remaining shorthand 0 breakpoints
-    if (bp.values.length === 0) {
-      bp.values.push(bp.breakpoint)
-      bp.breakpoint = '-'
-    }
-    return bp
-  })
+  // If the value bucket is not empty at the end, add it to a new '-' breakpoint
+  if (valueBucket.values.length > 0) {
+    bpScope.values.push(valueBucket)
+  }
+
+  if (tree.length === 0) {
+    tree.push(bpScope)
+  }
+
+  return tree
 }
 
 function parseBreakpoint(bp: string): BreakpointSpecifier {
@@ -152,7 +165,20 @@ export function toCss(
           `(${b.condition?.includes('<') ? 'max-width' : 'min-width'}: ${viewportBreakpoints[b.value] ?? b.value})`,
       )
       .join(' and ')
-    const mq = `@media ${query} {${selector}{${styleTemplate(property, bp.values.map(valueTemplate))}}}`
+
+    // For each set of values in the breakpoint, construct a selector based on the
+    // specified selector and the base selector, and apply the style template to each
+    const mq = `@media ${query} {${bp.values
+      .map((bpValues: BreakpointValues) => {
+        let sel = selector
+        if (bpValues.sel.length > 0)
+          sel =
+            selector === ':host'
+              ? `:host(:${bpValues.sel}`
+              : `${selector}:${bpValues.sel}`
+        return `${sel}{${styleTemplate(property, bpValues.values.map(valueTemplate))}}`
+      })
+      .join('')}}`
     css += mq
   }
 

--- a/libs/core/src/utils/helpers/style-expression-parser.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser.ts
@@ -176,7 +176,17 @@ export function toCss(
             selector === ':host'
               ? `:host(:${bpValues.sel})`
               : `${selector}:${bpValues.sel}`
-        return `${sel}{${styleTemplate(property, bpValues.values.map(valueTemplate))}}`
+
+        const style = styleTemplate(
+          property,
+          bpValues.values.map(valueTemplate),
+        )
+
+        // If the selector is hover, we wrap the style in a hover media query so that
+        // it excludes touch devices
+        if (bpValues.sel === 'hover')
+          return `@media (hover: hover) {${sel}{${style}}}`
+        else return `${sel}{${style}}`
       })
       .join('')}}`
     css += mq

--- a/libs/core/src/utils/helpers/style-expression-parser.ts
+++ b/libs/core/src/utils/helpers/style-expression-parser.ts
@@ -174,7 +174,7 @@ export function toCss(
         if (bpValues.sel.length > 0)
           sel =
             selector === ':host'
-              ? `:host(:${bpValues.sel}`
+              ? `:host(:${bpValues.sel})`
               : `${selector}:${bpValues.sel}`
         return `${sel}{${styleTemplate(property, bpValues.values.map(valueTemplate))}}`
       })


### PR DESCRIPTION
This PR adds support for specifying pseudo selectors like `:hover`, `:focus`, etc, in Style Expression Properties.

For example: 
```html
<gds-card padding="xs; hover: xs s; >l { s m; hover: xl }"></gds-card>
```

Sub-selectors are specified by prefixing a value sequence with `xxx:`, and selector/value sequences are terminated by `;`
The sub-selector will then be appended/merged with the base selector, ie `:host(:xxx)` or `.some-sel:xxx`. The `;` is only mandatory when there are more than one sequence, meaning that this upgrade will be backwards-compatible with existing expressions.

Here is a slightly more realistic example, changing the border and padding on hover:

```html
<gds-card
  radius="s"
  border="4xs/l2-stroke-primary; hover: s/l2-stroke-primary"
  padding="xl; hover: l"
  background="l2-background-secondary"
>
...
</gds-card>
```