### PR TITLE
chore(chlorophyll): change transparentize to color.adjust

### DIFF
--- a/.changeset/weak-wolves-fix.md
+++ b/.changeset/weak-wolves-fix.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/chlorophyll': patch
+---
+
+change transparentize to color.adjust

--- a/libs/chlorophyll/scss/components/themes/_mixins.scss
+++ b/libs/chlorophyll/scss/components/themes/_mixins.scss
@@ -104,7 +104,7 @@ Values for light mode are used by default.
   )
   /* border */,
   $border-color: var(--gds-ref-pallet-base600),
-  // color.adjust($black, -0.83),
+  // color.adjust($black, $alpha: -0.83),
   // #CECECE against white
   $border-width: 1px,
   $border-radius: 0.25rem,
@@ -307,8 +307,8 @@ Values for light mode are used by default.
     $text-primary: $grey-100,
     $text-secondary: $grey-200,
     $border-color: $grey-200,
-    $form-control-bg: #{color.adjust(#000000, -0.9)},
-    $form-control-bg-disabled: color.adjust(#ffffff, -0.98),
+    $form-control-bg: #{color.adjust(#000000, $alpha: -0.9)},
+    $form-control-bg-disabled: color.adjust(#ffffff, $alpha: -0.98),
     $skeleton-loader-highlight: $grey-400,
     $skeleton-loader-background: $grey-600
   );

--- a/libs/chlorophyll/scss/components/themes/_mixins.scss
+++ b/libs/chlorophyll/scss/components/themes/_mixins.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use 'sass:math';
+@use 'sass:color';
 @use '../../common/functions';
 
 /* Mixin for adding themes,
@@ -103,7 +104,7 @@ Values for light mode are used by default.
   )
   /* border */,
   $border-color: var(--gds-ref-pallet-base600),
-  // transparentize($black, 0.83),
+  // color.adjust($black, -0.83),
   // #CECECE against white
   $border-width: 1px,
   $border-radius: 0.25rem,
@@ -306,8 +307,8 @@ Values for light mode are used by default.
     $text-primary: $grey-100,
     $text-secondary: $grey-200,
     $border-color: $grey-200,
-    $form-control-bg: #{transparentize(#000000, 0.9)},
-    $form-control-bg-disabled: transparentize(#ffffff, 0.98),
+    $form-control-bg: #{color.adjust(#000000, -0.9)},
+    $form-control-bg-disabled: color.adjust(#ffffff, -0.98),
     $skeleton-loader-highlight: $grey-400,
     $skeleton-loader-background: $grey-600
   );

--- a/libs/chlorophyll/scss/tokens/_shame.scss
+++ b/libs/chlorophyll/scss/tokens/_shame.scss
@@ -179,11 +179,11 @@ $disabled: (
     'primary-border': var(--gds-ref-pallet-base500),
   ),
   dark: (
-    'background': color.adjust($white, -0.98),
-    'color': color.adjust($white, -0.93),
+    'background': color.adjust($white, $alpha: -0.98),
+    'color': color.adjust($white, $alpha: -0.93),
     'border': get($grey, 400, 'dark'),
-    'primary-background': color.adjust($white, -0.98),
-    'primary-color': color.adjust($white, -0.93),
+    'primary-background': color.adjust($white, $alpha: -0.98),
+    'primary-color': color.adjust($white, $alpha: -0.93),
     'primary-border': get($grey, 400, 'dark'),
   ),
 );
@@ -272,8 +272,8 @@ $form-control-primary-bg-disabled: var(--form-control-primary-bg-disabled);
 /* stylelint-disable */
 @mixin dark-mode() {
   --heading-primary-color: #{$white};
-  --text-primary-color: #{color.adjust($white, -0.1)};
-  --text-secondary-color: #{color.adjust($white, -0.4)};
+  --text-primary-color: #{color.adjust($white, $alpha: -0.1)};
+  --text-secondary-color: #{color.adjust($white, $alpha: -0.4)};
   --text-disabled-color: #{get($disabled, 'color', 'dark')};
   --text-primary-disabled-color: #{get($disabled, 'primary-color', 'dark')};
   --border-color: #{get($grey, 500, 'dark')};
@@ -312,8 +312,8 @@ $form-control-primary-bg-disabled: var(--form-control-primary-bg-disabled);
   --text-secondary-color: #{get($grey, 800, 'light')};
   --text-disabled-color: var(--gds-ref-pallet-base600);
   --text-primary-disabled-color: #{get($disabled, 'primary-color')};
-  --border-color: #{color.adjust($black, -0.83)}; // #CECECE against white
-  --border-secondary-color: #{color.adjust($black, -0.9)};
+  --border-color: #{color.adjust($black, $alpha: -0.83)}; // #CECECE against white
+  --border-secondary-color: #{color.adjust($black, $alpha: -0.9)};
   --border-disabled-color: #{get($disabled, 'border')};
   --border-primary-disabled-color: #{get($disabled, 'primary-border')};
   --border-color-invalid: #{get($intent, 'danger')};

--- a/libs/chlorophyll/scss/tokens/_shame.scss
+++ b/libs/chlorophyll/scss/tokens/_shame.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use 'sass:color';
 @use '../common/functions';
 @function get($property, $value, $theme: light) {
   @return map.get(map.get($property, $theme), $value);
@@ -178,11 +179,11 @@ $disabled: (
     'primary-border': var(--gds-ref-pallet-base500),
   ),
   dark: (
-    'background': transparentize($white, 0.98),
-    'color': transparentize($white, 0.93),
+    'background': color.adjust($white, -0.98),
+    'color': color.adjust($white, -0.93),
     'border': get($grey, 400, 'dark'),
-    'primary-background': transparentize($white, 0.98),
-    'primary-color': transparentize($white, 0.93),
+    'primary-background': color.adjust($white, -0.98),
+    'primary-color': color.adjust($white, -0.93),
     'primary-border': get($grey, 400, 'dark'),
   ),
 );
@@ -271,8 +272,8 @@ $form-control-primary-bg-disabled: var(--form-control-primary-bg-disabled);
 /* stylelint-disable */
 @mixin dark-mode() {
   --heading-primary-color: #{$white};
-  --text-primary-color: #{transparentize($white, 0.1)};
-  --text-secondary-color: #{transparentize($white, 0.4)};
+  --text-primary-color: #{color.adjust($white, -0.1)};
+  --text-secondary-color: #{color.adjust($white, -0.4)};
   --text-disabled-color: #{get($disabled, 'color', 'dark')};
   --text-primary-disabled-color: #{get($disabled, 'primary-color', 'dark')};
   --border-color: #{get($grey, 500, 'dark')};
@@ -311,8 +312,8 @@ $form-control-primary-bg-disabled: var(--form-control-primary-bg-disabled);
   --text-secondary-color: #{get($grey, 800, 'light')};
   --text-disabled-color: var(--gds-ref-pallet-base600);
   --text-primary-disabled-color: #{get($disabled, 'primary-color')};
-  --border-color: #{transparentize($black, 0.83)}; // #CECECE against white
-  --border-secondary-color: #{transparentize($black, 0.9)};
+  --border-color: #{color.adjust($black, -0.83)}; // #CECECE against white
+  --border-secondary-color: #{color.adjust($black, -0.9)};
   --border-disabled-color: #{get($disabled, 'border')};
   --border-primary-disabled-color: #{get($disabled, 'primary-border')};
   --border-color-invalid: #{get($intent, 'danger')};


### PR DESCRIPTION
Our Rspack build gave warnings that we were using deprecated features from Chlorophyll:

```bash
WARNING in ./src/components/spinner/spinner.scss (../../../node_modules/css-loader/dist/cjs.js!../../../node_modules/sass-loader/dist/cjs.js!./src/components/spinner/spinner.scss)
  ⚠ ModuleWarning: Deprecation Warning on line 313, column 20 of file:///<REPO>/node_modules/@sebgroup/chlorophyll/scss/tokens/_shame.scss:313:20:
  │ transparentize() is deprecated. Suggestions:
  │
  │ color.scale($color, $alpha: -83%)
  │ color.adjust($color, $alpha: -0.83)
  │
  │ More info: https://sass-lang.com/d/color-functions
  │
  │ 313 |   --border-color: #{transparentize($black, 0.83)}; // #CECECE against white
```

This should get rid of these warnings. 

I don't know how to test this, would be appreciated if you could verify that the output is the same.