### PR TITLE
Better react slider examples

### DIFF
--- a/libs/react/src/lib/slider/slider.mdx
+++ b/libs/react/src/lib/slider/slider.mdx
@@ -65,3 +65,7 @@ On pages where the user can experiment or adjust values in a scale, such as "How
 ### Disabled
 
 <Canvas of={SliderStories.Disabled} />
+
+### Showing high numbers
+
+<Canvas of={SliderStories.HighNumber} />

--- a/libs/react/src/lib/slider/slider.stories.tsx
+++ b/libs/react/src/lib/slider/slider.stories.tsx
@@ -115,6 +115,13 @@ export default {
 export const Default = {
   render: Template.bind({}),
   name: 'Default',
+  
+
+  args: {
+    label: 'Slider label text in one line',
+    instruction: 'Element instruction',
+    value: 0,
+  },
 }
 
 export const Textbox = {
@@ -122,6 +129,9 @@ export const Textbox = {
   name: 'Textbox',
 
   args: {
+    label: 'Slider label text in one line',
+    instruction: 'Element instruction',
+    value: 50,
     hasTextbox: true,
   },
 }
@@ -131,6 +141,9 @@ export const UnitTextbox = {
   name: 'UnitTextbox',
 
   args: {
+    label: 'Slider label text in one line',
+    instruction: 'Element instruction',
+    value: 50,
     hasTextbox: true,
     unitLabel: 'kr',
     showMinMax: true,
@@ -142,6 +155,9 @@ export const Error = {
   name: 'Error',
 
   args: {
+    label: 'Slider label text in one line',
+    instruction: 'Element instruction',
+    value: 50,
     hasTextbox: true,
     errorMessage: 'Error text can be quite long',
   },
@@ -152,7 +168,24 @@ export const Disabled = {
   name: 'Disabled',
 
   args: {
+    label: 'Slider label text in one line',
+    instruction: 'Element instruction',
+    value: 50,
     hasTextbox: true,
     disabled: true,
+  },
+}
+
+export const HighNumber = {
+  render: Template.bind({}),
+  name: 'HighNumber',
+
+  args: {
+    label: 'Slider label text in one line',
+    instruction: 'Element instruction',
+    min: 3000,
+    max: 15000,
+    value: 5000,
+    hasTextbox: true,
   },
 }


### PR DESCRIPTION
Slider storybook for react now shows label and sublabel, along with default value and a big number example.

Will make it easier to understand and bug test slider in react. Now is much more similar to the examples in Angular.