### PR TITLE
grid gap fix

### DIFF
--- a/.changeset/wet-cows-begin.md
+++ b/.changeset/wet-cows-begin.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-core': patch
 ---
 
-switching gap to have <row-value> <column-value> as css spec https://developer.mozilla.org/en-US/docs/Web/CSS/gap#values
+**Grid:** switching gap to have <row-value> <column-value> as css spec https://developer.mozilla.org/en-US/docs/Web/CSS/gap#values

--- a/.changeset/wet-cows-begin.md
+++ b/.changeset/wet-cows-begin.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+switching gap to have <row-value> <column-value> as css spec https://developer.mozilla.org/en-US/docs/Web/CSS/gap#values

--- a/libs/core/src/components/layout/grid/grid.ts
+++ b/libs/core/src/components/layout/grid/grid.ts
@@ -43,8 +43,8 @@ export class GdsGrid extends GdsContainer {
    */
   @styleExpressionProperty({
     styleTemplate: (_prop, values) => {
-      const colGap = values[0]
-      const rowGap = values[1] || colGap
+      const rowGap = values[0]
+      const colGap = values[1] || rowGap
       return `--_gap-column: ${colGap}; --_gap-row: ${rowGap};`
     },
   })


### PR DESCRIPTION
This pull request includes changes to the `@sebgroup/green-core` package and the `GdsGrid` component to align with the CSS specification for the `gap` property. The most important changes include updating the `gap` property handling and modifying the `GdsGrid` component to switch the order of row and column values.

Modifications to `GdsGrid` component:

* [`libs/core/src/components/layout/grid/grid.ts`](diffhunk://#diff-1afc0b4bc6a6dc96b354526bfd9f753b3727e8d75ce5ddeb2b6c5d52e4918ad5L46-R47): Changed the `styleTemplate` function to switch the order of `rowGap` and `colGap` values to align with the CSS specification. (`[libs/core/src/components/layout/grid/grid.tsL46-R47](diffhunk://#diff-1afc0b4bc6a6dc96b354526bfd9f753b3727e8d75ce5ddeb2b6c5d52e4918ad5L46-R47)`)