### PR TITLE
Refactor Segmented Control

### DIFF
--- a/.changeset/olive-ads-unite.md
+++ b/.changeset/olive-ads-unite.md
@@ -2,7 +2,7 @@
 '@sebgroup/green-core': minor
 ---
 
-**Segmented Control:** Add support for variable width segments
+**Segmented Control:** Add support for variable width segments. Fixes #1603
 
 This change refactors a large chunk of the Segmented Control implementation:
 

--- a/.changeset/olive-ads-unite.md
+++ b/.changeset/olive-ads-unite.md
@@ -1,0 +1,13 @@
+---
+'@sebgroup/green-core': minor
+---
+
+**Segmented Control:** Add support for variable width segments
+
+This change refactors a large chunk of the Segmented Control implementation:
+
+- Rewrite layout code to use `css-scroll-snap`
+- Remove `seg-min-width`
+- Add style expression properties to `gds-segment` for size control
+
+A side-effect of this change is that segments will no longer align to the right end of the control when they overflow.

--- a/libs/core/setup-jest.js
+++ b/libs/core/setup-jest.js
@@ -35,3 +35,10 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 })
+
+global.IntersectionObserver = class IntersectionObserver {
+  constructor() {}
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}

--- a/libs/core/src/components/segmented-control/segment/segment.style.css
+++ b/libs/core/src/components/segmented-control/segment/segment.style.css
@@ -1,6 +1,5 @@
 :host {
   display: flex;
-  transition: 0.2s;
   z-index: 1;
 }
 

--- a/libs/core/src/components/segmented-control/segment/segment.style.css
+++ b/libs/core/src/components/segmented-control/segment/segment.style.css
@@ -20,6 +20,7 @@ button {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
+  transition: 0.1s;
 
   &:disabled {
     cursor: not-allowed;
@@ -28,7 +29,7 @@ button {
 }
 
 @media (pointer: fine) {
-  button:hover {
+  :host(:not([selected])) button:hover {
     background-color: color-mix(
       in srgb,
       var(--gds-sys-color-state-layers-state-black-dim1),

--- a/libs/core/src/components/segmented-control/segment/segment.ts
+++ b/libs/core/src/components/segmented-control/segment/segment.ts
@@ -34,6 +34,16 @@ export class GdsSegment<ValueT = any> extends GdsElement {
   @property({ type: Boolean, reflect: true })
   disabled = false
 
+  /**
+   * Whether the segment is currently visible.
+   */
+  get isVisible() {
+    return this._isVisible
+  }
+  // This is deliberatly not marked as private, since we're setting it from the parent component,
+  // but it is not meant to be set by the consumer.
+  _isVisible = true
+
   connectedCallback(): void {
     super.connectedCallback()
     TransitionalStyles.instance.apply(this, 'gds-segmented')

--- a/libs/core/src/components/segmented-control/segment/segment.ts
+++ b/libs/core/src/components/segmented-control/segment/segment.ts
@@ -6,6 +6,7 @@ import { unsafeCSS } from 'lit'
 
 import { tokens } from '../../../tokens.style'
 import style from './segment.style.css?inline'
+import { styleExpressionProperty } from '../../../utils/decorators/style-expression-property'
 
 /**
  * @element gds-segment
@@ -33,6 +34,28 @@ export class GdsSegment<ValueT = any> extends GdsElement {
    */
   @property({ type: Boolean, reflect: true })
   disabled = false
+
+  /**
+   * Controls the `min-width` css property of the segment.
+   */
+  @styleExpressionProperty({
+    valueTemplate: (v) => v,
+  })
+  'min-width'?: string
+
+  /**
+   * Controls the `max-width` css property of the segment.
+   */
+  @styleExpressionProperty({
+    valueTemplate: (v) => v,
+  })
+  'max-width'?: string
+
+  /**
+   * Controls the `width` css property of the segment.
+   */
+  @styleExpressionProperty()
+  width?: string
 
   /**
    * Whether the segment is currently visible.

--- a/libs/core/src/components/segmented-control/segmented-control.stories.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.stories.ts
@@ -90,7 +90,7 @@ export const Small: Story = {
 export const SegmentSize: Story = {
   ...DefaultParams,
   render: (args) => html`
-    <div style="max-width: 800px">
+    <div style="width:100vw; max-width: 700px;">
       <gds-segmented-control seg-min-width="200" value="3">
         <gds-segment value="1">First</gds-segment>
         <gds-segment value="2">Unusually long label text</gds-segment>

--- a/libs/core/src/components/segmented-control/segmented-control.stories.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.stories.ts
@@ -12,7 +12,7 @@ import './index.ts'
 const meta: Meta = {
   title: 'Docs/Components/Segmented Control',
   component: 'gds-segmented-control',
-  subcomponents: { MenuItem: 'gds-segment' },
+  subcomponents: { GdsSegment: 'gds-segment' },
   parameters: {
     layout: 'centered',
   },
@@ -82,21 +82,24 @@ export const Small: Story = {
 }
 
 /**
- * The size of the segments can be configured using the `seg-min-width` attribute. This influences
- * how many segments will be visible at the same time. If you have long segment labels and want to
- * avoid concatenation, you can increase the `seg-min-width` attribute. But keep in mind that the
- * best practice is to keep the segment labels short.
+ * Segments can have different widths depending on the content, and if there are too many
+ * segments to fit in the container, scroll buttons will appear to the left and/or right.
+ *
+ * Segment with can also be controlled individually on the segments using the `width`,
+ * `min-width` and `max-width` Style Expression properties.
  */
 export const SegmentSize: Story = {
   ...DefaultParams,
   render: (args) => html`
-    <div style="width:90vw; max-width: 700px;">
-      <gds-segmented-control value="3">
-        <gds-segment value="1">First</gds-segment>
-        <gds-segment value="2">Unusually long label text</gds-segment>
-        <gds-segment value="3">Third</gds-segment>
-        <gds-segment value="4">Fourth</gds-segment>
-        <gds-segment value="5">Fifth</gds-segment>
+    <div style="width:90vw; max-width: 500px;">
+      <gds-segmented-control value="1">
+        <gds-segment value="1" min-width="200px">Min-width</gds-segment>
+        <gds-segment value="flaschenabfüllmaschine" max-width="150px"
+          >Flaschenabfüllmaschine</gds-segment
+        >
+        <gds-segment value="longlonglong">Long long label</gds-segment>
+        <gds-segment value="longlabel">An even longer long label</gds-segment>
+        <gds-segment value="pinetrees">Pinetrees</gds-segment>
       </gds-segmented-control>
     </div>
   `,

--- a/libs/core/src/components/segmented-control/segmented-control.stories.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.stories.ts
@@ -90,8 +90,8 @@ export const Small: Story = {
 export const SegmentSize: Story = {
   ...DefaultParams,
   render: (args) => html`
-    <div style="width:100vw; max-width: 700px;">
-      <gds-segmented-control seg-min-width="200" value="3">
+    <div style="width:90vw; max-width: 700px;">
+      <gds-segmented-control value="3">
         <gds-segment value="1">First</gds-segment>
         <gds-segment value="2">Unusually long label text</gds-segment>
         <gds-segment value="3">Third</gds-segment>

--- a/libs/core/src/components/segmented-control/segmented-control.style.css
+++ b/libs/core/src/components/segmented-control/segmented-control.style.css
@@ -5,7 +5,6 @@
   box-sizing: border-box;
   contain: layout;
   display: inline-flex;
-  /* gap: 0.25rem; */
   height: 3rem;
   width: 100%;
   position: relative;
@@ -25,9 +24,7 @@
   scroll-behavior: smooth;
   overflow-x: scroll;
   gap: 0.25rem;
-  box-sizing: border-box;
   position: relative;
-
   scrollbar-width: none;
 }
 
@@ -52,7 +49,6 @@
   justify-content: center;
   width: 2.5rem;
   transition: 0.2s;
-  position: relative;
   z-index: 2;
   position: absolute;
 

--- a/libs/core/src/components/segmented-control/segmented-control.style.css
+++ b/libs/core/src/components/segmented-control/segmented-control.style.css
@@ -18,20 +18,15 @@
 #track {
   box-sizing: border-box;
   display: flex;
-  flex-grow: 0;
-  flex-shrink: 1;
+  flex-grow: 1;
+  scroll-snap-type: inline mandatory;
+  overscroll-behavior-x: contain;
+  scroll-behavior: smooth;
   overflow: hidden;
   position: relative;
-  width: 100%;
-}
-
-#segments {
-  box-sizing: border-box;
-  display: inline-flex;
   gap: 0.25rem;
+  box-sizing: border-box;
   position: relative;
-  transition: 0.2s;
-  z-index: 1;
 }
 
 #btn-prev,
@@ -70,6 +65,7 @@
   flex-grow: 1;
   flex-shrink: 0;
   z-index: 1;
+  scroll-snap-align: start;
 }
 
 #indicator {

--- a/libs/core/src/components/segmented-control/segmented-control.style.css
+++ b/libs/core/src/components/segmented-control/segmented-control.style.css
@@ -5,9 +5,10 @@
   box-sizing: border-box;
   contain: layout;
   display: inline-flex;
-  gap: 0.25rem;
+  /* gap: 0.25rem; */
   height: 3rem;
   width: 100%;
+  position: relative;
   overflow: hidden;
 }
 
@@ -23,10 +24,10 @@
   overscroll-behavior-x: contain;
   scroll-behavior: smooth;
   overflow-x: scroll;
-  position: relative;
   gap: 0.25rem;
   box-sizing: border-box;
   position: relative;
+
   scrollbar-width: none;
 }
 
@@ -36,6 +37,7 @@
 
 #btn-prev,
 #btn-next {
+  box-sizing: border-box;
   align-items: center;
   appearance: none;
   aspect-ratio: 1;
@@ -49,6 +51,10 @@
   height: 100%;
   justify-content: center;
   width: 2.5rem;
+  transition: 0.2s;
+  position: relative;
+  z-index: 2;
+  position: absolute;
 
   @media (pointer: fine) {
     &:hover {
@@ -60,6 +66,21 @@
     }
   }
 }
+#btn-prev {
+  margin: 0 0.25rem 0 0;
+}
+#btn-next {
+  margin: 0 0 0 0.25rem;
+  right: 0;
+}
+
+#btn-prev[aria-hidden='true'],
+#btn-next[aria-hidden='true'] {
+  opacity: 0;
+  width: 0;
+  margin: 0;
+  padding: 0;
+}
 
 :host([size='small']) #btn-prev,
 :host([size='small']) #btn-next {
@@ -70,6 +91,7 @@
   flex-grow: 1;
   flex-shrink: 0;
   z-index: 1;
+  scroll-margin: 0 2.75rem;
   scroll-snap-align: start;
 }
 
@@ -79,6 +101,7 @@
   height: 100%;
   left: 0;
   position: absolute;
+  z-index: 0;
   transition:
     transform 0.2s,
     width 0.2s;

--- a/libs/core/src/components/segmented-control/segmented-control.style.css
+++ b/libs/core/src/components/segmented-control/segmented-control.style.css
@@ -7,7 +7,7 @@
   display: inline-flex;
   gap: 0.25rem;
   height: 3rem;
-  max-width: 100%;
+  width: 100%;
   overflow: hidden;
 }
 

--- a/libs/core/src/components/segmented-control/segmented-control.style.css
+++ b/libs/core/src/components/segmented-control/segmented-control.style.css
@@ -22,11 +22,16 @@
   scroll-snap-type: inline mandatory;
   overscroll-behavior-x: contain;
   scroll-behavior: smooth;
-  overflow: hidden;
+  overflow-x: scroll;
   position: relative;
   gap: 0.25rem;
   box-sizing: border-box;
   position: relative;
+  scrollbar-width: none;
+}
+
+#track::-webkit-scrollbar {
+  display: none;
 }
 
 #btn-prev,

--- a/libs/core/src/components/segmented-control/segmented-control.test.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.test.ts
@@ -133,5 +133,20 @@ describe('<gds-segmented-control>', () => {
       const prevButton = el.shadowRoot?.querySelector('#btn-prev')
       waitUntil(() => prevButton?.getAttribute('aria-hidden') === 'false')
     })
+
+    it('<gds-segment> should support min-width, max-width and width style expression properties', async () => {
+      const el = await fixture<GdsSegmentedControl>(html`
+        <gds-segmented-control style="max-width: 300px">
+          <gds-segment min-width="100px">Segment 1</gds-segment>
+          <gds-segment max-width="200px">Segment 2</gds-segment>
+          <gds-segment width="150px">Segment 3</gds-segment>
+        </gds-segmented-control>
+      `)
+
+      const segments = el.segments
+      expect(segments[0]['min-width']).to.equal('100px')
+      expect(segments[1]['max-width']).to.equal('200px')
+      expect(segments[2]['width']).to.equal('150px')
+    })
   })
 })

--- a/libs/core/src/components/segmented-control/segmented-control.test.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.test.ts
@@ -1,5 +1,10 @@
 import { expect } from '@esm-bundle/chai'
-import { fixture, html as testingHtml, aTimeout } from '@open-wc/testing'
+import {
+  fixture,
+  html as testingHtml,
+  aTimeout,
+  waitUntil,
+} from '@open-wc/testing'
 import { sendKeys, sendMouse } from '@web/test-runner-commands'
 import { clickOnElement } from '../../utils/testing'
 import sinon from 'sinon'
@@ -95,37 +100,38 @@ describe('<gds-segmented-control>', () => {
 
     it('renders the next button when segments overflow', async () => {
       const el = await fixture<GdsSegmentedControl>(html`
-        <gds-segmented-control seg-min-width="120" style="max-width: 300px">
-          <gds-segment>Segment 1</gds-segment>
-          <gds-segment>Segment 2</gds-segment>
-          <gds-segment>Segment 3</gds-segment>
-          <gds-segment>Segment 4</gds-segment>
+        <gds-segmented-control style="max-width: 300px">
+          <gds-segment min-width="100px">Segment 1</gds-segment>
+          <gds-segment min-width="100px">Segment 2</gds-segment>
+          <gds-segment min-width="100px">Segment 3</gds-segment>
+          <gds-segment min-width="100px">Segment 4</gds-segment>
         </gds-segmented-control>
       `)
 
       await el.updateComplete
 
       const nextButton = el.shadowRoot?.querySelector('#btn-next')
-      expect(nextButton).to.exist
+      waitUntil(() => nextButton?.getAttribute('aria-hidden') === 'false')
     })
 
     it('renders the prev button when segments overflow', async () => {
       const el = await fixture<GdsSegmentedControl>(html`
-        <gds-segmented-control seg-min-width="120" style="max-width: 300px">
-          <gds-segment>Segment 1</gds-segment>
-          <gds-segment>Segment 2</gds-segment>
-          <gds-segment>Segment 3</gds-segment>
-          <gds-segment>Segment 4</gds-segment>
+        <gds-segmented-control style="max-width: 300px">
+          <gds-segment min-width="100px">Segment 1</gds-segment>
+          <gds-segment min-width="100px">Segment 2</gds-segment>
+          <gds-segment min-width="100px">Segment 3</gds-segment>
+          <gds-segment min-width="100px">Segment 4</gds-segment>
         </gds-segmented-control>
       `)
 
       await el.updateComplete
 
       const nextButton = el.shadowRoot?.querySelector('#btn-next')
+      waitUntil(() => nextButton?.getAttribute('aria-hidden') === 'false')
       clickOnElement(nextButton as HTMLElement)
-      await aTimeout(100)
+
       const prevButton = el.shadowRoot?.querySelector('#btn-prev')
-      expect(prevButton).to.exist
+      waitUntil(() => prevButton?.getAttribute('aria-hidden') === 'false')
     })
   })
 })

--- a/libs/core/src/components/segmented-control/segmented-control.test.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.test.ts
@@ -93,15 +93,6 @@ describe('<gds-segmented-control>', () => {
       expect(spy).to.have.been.calledOnce
     })
 
-    it('should set the segMinWidth property based on the seg-min-width attribute', async () => {
-      const el = await fixture<GdsSegmentedControl>(
-        html`<gds-segmented-control
-          seg-min-width="120"
-        ></gds-segmented-control>`,
-      )
-      expect(el.segMinWidth).to.equal(120)
-    })
-
     it('renders the next button when segments overflow', async () => {
       const el = await fixture<GdsSegmentedControl>(html`
         <gds-segmented-control seg-min-width="120" style="max-width: 300px">

--- a/libs/core/src/components/segmented-control/segmented-control.trans.styles.css
+++ b/libs/core/src/components/segmented-control/segmented-control.trans.styles.css
@@ -25,21 +25,17 @@
       display: flex;
       flex-grow: 0;
       flex-shrink: 1;
-      overflow: hidden;
+      scroll-snap-type: inline mandatory;
+      overscroll-behavior-x: contain;
+      scroll-behavior: smooth;
+      overflow-x: scroll;
       position: relative;
       width: 100%;
+      scrollbar-width: none;
     }
 
-    #segments {
-      box-sizing: border-box;
-      display: inline-flex;
-      position: relative;
-      transition: 0.2s;
-      z-index: 1;
-    }
-
-    #segments > * {
-      flex: 1 1 auto;
+    #track::-webkit-scrollbar {
+      display: none;
     }
 
     #btn-prev,
@@ -56,6 +52,9 @@
       height: 100%;
       justify-content: center;
       width: 2.5rem;
+      z-index: 2;
+      position: absolute;
+      transition: 0.2s;
 
       @media (pointer: fine) {
         &:hover {
@@ -67,6 +66,18 @@
     #btn-prev {
       border-right: 1px solid #333;
     }
+    #btn-next {
+      border-left: 1px solid #333;
+      right: 0;
+    }
+
+    #btn-prev[aria-hidden='true'],
+    #btn-next[aria-hidden='true'] {
+      opacity: 0;
+      width: 0;
+      margin: 0;
+      padding: 0;
+    }
 
     :host([size='small']) #btn-prev,
     :host([size='small']) #btn-next {
@@ -77,6 +88,8 @@
       flex-grow: 1;
       flex-shrink: 0;
       z-index: 1;
+      scroll-margin: 0 2.5rem;
+      scroll-snap-align: start;
     }
 
     #indicator {

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -16,14 +16,6 @@ import '../icon/icons/chevron-right'
 import { tokens } from '../../tokens.style'
 import style from './segmented-control.style.css?inline'
 
-const BTN_SIZE = {
-  small: 36,
-  medium: 44,
-}
-
-const getSegmentGap = (transitionalStyles: boolean) =>
-  transitionalStyles ? 0 : 4
-
 const debounce = (fn: () => void, delay: number) => {
   let timeoutId: NodeJS.Timeout
   return () => {
@@ -100,11 +92,8 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
     this.updateComplete.then(() => {
       this._elTrack.addEventListener('scroll', () => {
         this.#updateScrollBtnStateDebounced()
-        // this.#calcLayoutDebounced()
-        //this.#updateIndicator()
       })
     })
-    //setTimeout(() => this.#calcLayoutDebounced(), 100)
   }
 
   render() {
@@ -201,8 +190,6 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
     if (segment) {
       const segmentWidth = segment.offsetWidth
       const segmentLeft = segment.offsetLeft
-
-      //console.log(segmentWidth, segmentLeft)
 
       this._elIndicator.style.transform = `translateX(${segmentLeft}px)`
       this._elIndicator.style.width = `${segmentWidth}px`

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -229,6 +229,8 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
       (s, i, arr) => arr[i + 1]?.isVisible && !s.isVisible,
     )[0]
 
+    nextLeftOutOfView._isVisible = true
+    this.#updateScrollBtnState()
     nextLeftOutOfView.scrollIntoView()
   }
 
@@ -237,6 +239,8 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
       .filter((s, i, arr) => arr[i - 1]?.isVisible && !s.isVisible)
       .reverse()[0]
 
+    nextRightOutOfView._isVisible = true
+    this.#updateScrollBtnState()
     nextRightOutOfView.scrollIntoView()
   }
 

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -223,16 +223,19 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
   }
 
   #scrollLeft = () => {
-    this.segments
-      .filter((s, i, arr) => arr[i + 1]?.isVisible && !s.isVisible)[0]
-      .scrollIntoView()
+    const nextLeftOutOfView = this.segments.filter(
+      (s, i, arr) => arr[i + 1]?.isVisible && !s.isVisible,
+    )[0]
+
+    nextLeftOutOfView.scrollIntoView()
   }
 
   #scrollRight = () => {
-    this.segments
+    const nextRightOutOfView = this.segments
       .filter((s, i, arr) => arr[i - 1]?.isVisible && !s.isVisible)
       .reverse()[0]
-      .scrollIntoView()
+
+    nextRightOutOfView.scrollIntoView()
   }
 
   // Updates the visibility of the scroll buttons

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -214,7 +214,7 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
       {
         root: this._elTrack,
         rootMargin: '0px',
-        threshold: 0.1,
+        threshold: 0.5,
       },
     )
     this.segments.forEach((s) => {
@@ -232,7 +232,7 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
     this.segments
       .filter((s, i, arr) => arr[i - 1]?.isVisible && !s.isVisible)
       .reverse()[0]
-      .scrollIntoView({ block: 'end' })
+      .scrollIntoView()
   }
 
   // Updates the visibility of the scroll buttons

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -47,14 +47,6 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
   static styles = [tokens, unsafeCSS(style)]
 
   /**
-   * Minimum width of each segment. Used for calculating the number of visible
-   * segments that can fit based on the available space.
-   * @attr seg-min-width
-   */
-  @property({ type: Number, attribute: 'seg-min-width' })
-  segMinWidth = 100
-
-  /**
    * Size of the segmented control
    * @attr size
    */

--- a/libs/core/src/components/segmented-control/segmented-control.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.ts
@@ -291,7 +291,7 @@ export class GdsSegmentedControl<ValueT = any> extends GdsElement {
       if (selectedSegment) {
         this.segments.forEach((s) => (s.selected = false))
         selectedSegment.selected = true
-        this.#calcLayout(true)
+        selectedSegment.scrollIntoView()
       }
     })
   }

--- a/libs/react/.babelrc
+++ b/libs/react/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["@babel/preset-env", ["@nx/react/babel"]],
   "plugins": [
-    ["@babel/plugin-transform-private-property-in-object", { "loose": true }]
+    ["@babel/plugin-transform-private-property-in-object", { "loose": true }],
+    ["@babel/plugin-transform-private-methods", { "loose": true }]
   ]
 }


### PR DESCRIPTION
This change refactors a large chunk of the Segmented Control implementation:

- Rewrite layout code to use `css-scroll-snap`
- Remove `seg-min-width`
- Add style expression properties to `gds-segment` for size control

Related to #1603