### PR TITLE
Refactor how `gds-element` is set

### DIFF
--- a/.changeset/pink-sloths-walk.md
+++ b/.changeset/pink-sloths-walk.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Scoping:** Refactor how the `gds-element` attribute gets set

--- a/libs/core/src/gds-element.ts
+++ b/libs/core/src/gds-element.ts
@@ -1,6 +1,5 @@
 import { state } from 'lit/decorators.js'
 import { DynamicStylesController } from './dynamic-styles'
-import { getUnscopedTagName } from './scoping'
 import { LitElement } from 'lit'
 
 // This nis needed to support legacy decorators. Once we upgrade to TC39 standard decorators across the lib, we can remove this.
@@ -14,7 +13,7 @@ export class GdsElement extends LitElement {
    * @attribute gds-element
    * @readonly
    */
-  gdsElementName = ''
+  gdsElementName?: string
 
   /**
    * Whether the element is using transitional styles.
@@ -33,11 +32,8 @@ export class GdsElement extends LitElement {
     this._dynamicStylesController = new DynamicStylesController(this)
   }
 
-  // TODO: This is slow. We need to find a more efficient way of setting the gds-element attribute.
   connectedCallback(): void {
     super.connectedCallback()
-    this.gdsElementName =
-      getUnscopedTagName(this.tagName.toLowerCase()) || this.gdsElementName
-    this.setAttribute('gds-element', this.gdsElementName)
+    this.setAttribute('gds-element', this.gdsElementName?.toString() || '')
   }
 }


### PR DESCRIPTION
This PR refactors how the `gds-element` attribute is set on each gds element. Now it is set by the `gdsCustomElement` instead of on `connectedCallback()`. This makes it work even if the component is registered under a different element name, and also improve performance a bit since it no longer needs a lookup in the registry for each component instance.