### PR TITLE
Refactor the element lookup table to a global singleton

### DIFF
--- a/.changeset/calm-fireants-hear.md
+++ b/.changeset/calm-fireants-hear.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Scoped Elements:** Refactor the element lookup table as a global singleton rather than a module-scoped object.


### PR DESCRIPTION
This PR refactors the element lookup table as a global singleton rather than a module-scoped object. This should help in module federated scenarios where code has been split up into multiple dynamically loaded modules.

An added benefint is that it now becomes easier to troubleshoot scoping related issues, since you can simply inspect the singleton:
![image](https://github.com/user-attachments/assets/167dfe73-24eb-4f95-8807-504ecb7041fc)
