### PR TITLE
Dropdown scrollIntoView only after `updateComplete`

### DIFF
--- a/.changeset/happy-ads-look.md
+++ b/.changeset/happy-ads-look.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Dropdown:** Scroll into view after `updateComplete`

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -454,7 +454,7 @@ export class GdsDropdown<ValueT = any>
 
     const selectedOption = this.options.find((option) => option.selected)
 
-    selectedOption?.scrollIntoView()
+    this.updateComplete.then(() => selectedOption?.scrollIntoView())
 
     this.dispatchEvent(
       new CustomEvent('gds-ui-state', {


### PR DESCRIPTION
This fixes an issue where the whole page will scroll when opening the Dropdown