### PR TITLE
Remove Display Contents

### DIFF
--- a/.changeset/real-ways-brush.md
+++ b/.changeset/real-ways-brush.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Styling:** remove display:contents

--- a/libs/core/src/components/badge/badge.style.ts
+++ b/libs/core/src/components/badge/badge.style.ts
@@ -1,24 +1,20 @@
 import { css } from 'lit'
 
 const style = css`
-  @layer badge, shell, tokens, a11y, variants, types;
+  :host {
+    display: inline-block;
+  }
 
-  @layer badge {
-    :host {
-      display: contents;
-    }
+  slot[name='lead']::slotted(*) {
+    line-height: var(--gds-space-m);
+  }
 
-    slot[name='lead']::slotted(*) {
-      line-height: var(--gds-space-m);
-    }
+  :host([notification]) slot[name='trail']::slotted(*) {
+    line-height: var(--gds-space-s);
+  }
 
-    :host([notification]) slot[name='trail']::slotted(*) {
-      line-height: var(--gds-space-s);
-    }
-
-    :host([notification]) slot[name='lead']::slotted(*) {
-      line-height: var(--gds-space-s);
-    }
+  :host([notification]) slot[name='lead']::slotted(*) {
+    line-height: var(--gds-space-s);
   }
 `
 export default style

--- a/libs/core/src/components/content/divider/divider.style.ts
+++ b/libs/core/src/components/content/divider/divider.style.ts
@@ -2,7 +2,7 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    display: contents;
+    display: block;
   }
 
   hr {

--- a/libs/core/src/components/content/text/text.style.ts
+++ b/libs/core/src/components/content/text/text.style.ts
@@ -2,7 +2,7 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    display: contents;
+    display: block;
   }
 
   * {

--- a/libs/core/src/components/media/img/img.style.ts
+++ b/libs/core/src/components/media/img/img.style.ts
@@ -2,7 +2,7 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    display: contents;
+    display: block;
   }
 
   figure {

--- a/libs/core/src/components/media/video/video.style.ts
+++ b/libs/core/src/components/media/video/video.style.ts
@@ -2,7 +2,7 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    display: contents;
+    display: block;
   }
 
   figure {

--- a/libs/core/src/components/tooltip/style/tooltip.styles.css
+++ b/libs/core/src/components/tooltip/style/tooltip.styles.css
@@ -16,7 +16,7 @@
       --gds-tooltip-arrow: 6px;
       --gds-tooltip-radii: 8px;
       --gds-tooltip-transition-easing: var(--gds-sys-transition-easing);
-      display: contents;
+      display: inline-block;
       position: relative;
     }
 

--- a/libs/core/src/primitives/signal/signal.style.ts
+++ b/libs/core/src/primitives/signal/signal.style.ts
@@ -2,7 +2,7 @@ import { css } from 'lit'
 
 const style = css`
   :host {
-    display: contents;
+    display: inline-block;
   }
 
   [part='signal'] {


### PR DESCRIPTION
This pull request includes several changes to the styling of various components in the `libs/core/src` directory. The primary focus is on replacing the `display: contents` property with more appropriate display properties to improve layout and rendering.