### PR TITLE
Storybook port change

### DIFF
--- a/.changeset/unlucky-actors-perform.md
+++ b/.changeset/unlucky-actors-perform.md
@@ -1,0 +1,6 @@
+---
+'@sebgroup/green-angular': patch
+'@sebgroup/green-react': patch
+---
+
+storybook port change

--- a/libs/angular/project.json
+++ b/libs/angular/project.json
@@ -37,7 +37,7 @@
     "storybook": {
       "executor": "@storybook/angular:start-storybook",
       "options": {
-        "port": 4400,
+        "port": 4402,
         "configDir": "libs/angular/.storybook",
         "browserTarget": "angular:build-storybook",
         "compodoc": false,

--- a/libs/react/project.json
+++ b/libs/react/project.json
@@ -52,7 +52,7 @@
     "storybook": {
       "executor": "@nx/storybook:storybook",
       "options": {
-        "port": 4400,
+        "port": 4401,
         "configDir": "libs/react/.storybook"
       },
       "configurations": {


### PR DESCRIPTION
React now have fort 4401 as default and Angular 4402. So they don't have same as chlorophyl on 4400.