### PR TITLE
Fix `expandableInfoButtonLabel`

### DIFF
--- a/.changeset/fifty-terms-boil.md
+++ b/.changeset/fifty-terms-boil.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': patch
+---
+
+**Input:** Fix `expandableInfoButtonLabel`

--- a/.changeset/spotty-cars-exist.md
+++ b/.changeset/spotty-cars-exist.md
@@ -1,5 +1,5 @@
 ---
-'@sebgroup/green-react': major
+'@sebgroup/green-react': minor
 ---
 
 **IconButton:** Refactor to use `Button` internally and support same features as Button

--- a/.changeset/spotty-cars-exist.md
+++ b/.changeset/spotty-cars-exist.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': major
+---
+
+**IconButton:** Refactor to use `Button` internally and support same features as Button

--- a/libs/react/src/lib/form/iconButton/iconButton.tsx
+++ b/libs/react/src/lib/form/iconButton/iconButton.tsx
@@ -1,32 +1,13 @@
 import { ReactNode, MouseEvent, forwardRef, ForwardedRef } from 'react'
 import { ButtonType } from '@sebgroup/extract'
-
-interface IconButtonInterface {
-  children: ReactNode
-  type?: ButtonType
-  onClick: (event: MouseEvent) => void
-  'aria-expanded'?: boolean
-  'aria-controls'?: string
-  size?: 'small' | 'normal'
-  title?: string
-}
+import { Button, ButtonProps } from '../button/button'
 
 export const IconButton = forwardRef(
-  (
-    { children, onClick, ...props }: IconButtonInterface,
-    ref: ForwardedRef<HTMLButtonElement>,
-  ) => {
+  (props: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
     return (
-      <button
-        className={`icon ${props.size === 'small' && 'small'}`}
-        onClick={onClick}
-        aria-controls={props['aria-controls']}
-        aria-expanded={props['aria-expanded']}
-        type={props.type ?? 'button'}
-        ref={ref}
-      >
-        {children}
-      </button>
+      <Button {...props} className={`icon`} ref={ref}>
+        {props.children}
+      </Button>
     )
   },
 )

--- a/libs/react/src/lib/form/input/input.stories.tsx
+++ b/libs/react/src/lib/form/input/input.stories.tsx
@@ -35,6 +35,7 @@ export const WithExpandableInfo = {
   args: {
     label: 'Label',
     expandableInfo: 'Some info text',
+    expandableInfoButtonLabel: 'Show more info',
   },
 }
 

--- a/libs/react/src/lib/formItem/formItem.tsx
+++ b/libs/react/src/lib/formItem/formItem.tsx
@@ -105,6 +105,7 @@ export const FormItem = ({
             size="small"
             aria-expanded={isExpanded}
             aria-controls={`${inputId}-expandable-info`}
+            aria-label={expandableInfoButtonLabel}
             onClick={async (event) => {
               if (!isExpanded) {
                 setIsHidden(false)


### PR DESCRIPTION
This pull request includes minor updates to the `@sebgroup/green-react` library, focusing on improving the `IconButton` component and fixing an issue with the `expandableInfoButtonLabel` in the `FormItem` component.

### Improvements to `IconButton`:

* Refactored the `IconButton` component to use the `Button` component internally, ensuring it supports the same features as `Button`. (`libs/react/src/lib/form/iconButton/iconButton.tsx`)

### Fixes to `FormItem`:

* Output the `expandableInfoButtonLabel` property to the aria-label prop of the IconButton in the `FormItem` component to fix the label issue. (`libs/react/src/lib/formItem/formItem.tsx`)
* Updated the `WithExpandableInfo` story to include the `expandableInfoButtonLabel`. (`libs/react/src/lib/form/input/input.stories.tsx`)

### Changeset Updates:

* Added a patch changeset for fixing the `expandableInfoButtonLabel` issue. (`.changeset/fifty-terms-boil.md`)
* Added a minor changeset for the `IconButton` refactor. (`.changeset/spotty-cars-exist.md`)