### PR TITLE
Accordion: Can set aria-level in angular

### DIFF
--- a/.changeset/tame-gifts-approve.md
+++ b/.changeset/tame-gifts-approve.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+Accordion - Can set aria-level in angular

--- a/libs/angular/src/lib/accordion/accordion-list-item.component.html
+++ b/libs/angular/src/lib/accordion/accordion-list-item.component.html
@@ -1,5 +1,5 @@
 <ng-container data-testid="accordion-list-item-root">
-  <div role="heading" aria-level="2" [attr.id]="id">
+  <div role="heading" [attr.aria-level]="labelElementLevel" [attr.id]="id">
     <button
       data-testid="accordion-list-item-expander-button"
       [attr.id]="id + '_header'"

--- a/libs/angular/src/lib/accordion/accordion-list-item.component.ts
+++ b/libs/angular/src/lib/accordion/accordion-list-item.component.ts
@@ -8,6 +8,7 @@ import { randomId } from '@sebgroup/extract'
 })
 export class NggAccordionListItemComponent {
   @Input() public id: string = randomId()
+  @Input() public labelElementLevel = 2
   @Input() public listItemHeader = ''
   @Input() public listItemSubHeader = ''
   @Output() public expandedChange: EventEmitter<NggAccordionListItemComponent> =

--- a/libs/angular/src/lib/accordion/accordion.stories.ts
+++ b/libs/angular/src/lib/accordion/accordion.stories.ts
@@ -25,7 +25,7 @@ const Template: StoryFn<NggAccordionComponent> = () => {
             <div ngg-accordion-list-item listItemHeader="Second accordion heading" listItemSubHeader="Second accordion sublabel">
                 <p>This is the content of the second section</p>
             </div>
-            <div ngg-accordion-list-item listItemHeader="Third accordion heading" listItemSubHeader="Third accordion sublabel">
+            <div ngg-accordion-list-item labelElementLevel="3" listItemHeader="Third accordion heading - aria-level 3" listItemSubHeader="Third accordion sublabel">
               <p>This is the content of the second section</p>
             </div>
         </ngg-accordion>

--- a/libs/angular/src/lib/accordion/documentation.mdx
+++ b/libs/angular/src/lib/accordion/documentation.mdx
@@ -53,6 +53,7 @@ export class AppModule {}
 <Markdown>{`
 | Input             | Type     | Description                                                                                                                                              |
 | :---------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| labelElementLevel | \`integer\` | What aria-level (heading level) the accordion has. Can have value 1-6. Default 2.                                                                       |
 | listItemHeader    | \`string\` | The header of the expandable section. Will always be displayed regardless if the content is collapsed or expanded                                        |
 | listItemSubHeader | \`string\` | The subheader of the expandable section. Will always be displayed with a smaller font than the header regardless if the content is collapsed or expanded |
 | expandAll         | \`string\` | The sub header of the expandable section. Will always be displayed regardless if the content is collapsed or expanded                                    |


### PR DESCRIPTION
The aria-level (heading level) can now be set in Angular. Same as React can.
Closes: #1171