### PR TITLE
Alert Ribbon Close Button Fix

### DIFF
--- a/libs/chlorophyll/scss/components/alert-ribbon/alert-ribbon.stories.js
+++ b/libs/chlorophyll/scss/components/alert-ribbon/alert-ribbon.stories.js
@@ -27,6 +27,12 @@ export default {
     closeButton: {
       control: 'boolean',
     },
+    isCloseable: {
+      control: 'boolean',
+    },
+    closeText: {
+      control: 'text',
+    },
   },
 }
 
@@ -35,7 +41,7 @@ export default {
  * &nbsp;|&nbsp;
  * [Usage guidelines](https://designlibrary.sebgroup.com/components/component-alertribbon)
  *
- * An alert ribbon is a message used to inform the user about the state of a system, page or function. Icons and color indicate the type and urgency of the information within the message.
+ * An alert ribbon is a message used to inform the user about the state of a system, page or function. Icons and color indicate the type and urgency of the information within the message. Note that 'closeButton' will be depricated and replaced by 'isCloseable'.
  */
 export const AlertRibbon = {
   render: (args) => `
@@ -53,8 +59,11 @@ export const AlertRibbon = {
       </p>
     </div>
     ${
-      args.closeButton
-        ? `<button class="close" type="button"><span class="sr-only">Close</span><i></i></button>`
+      args.isCloseable || args.closeButton
+        ? (
+          args.closeText
+          ? `<button class="close" aria-label="` + args.closeText + `" type="button"><i></i></button>`
+          : `<button class="close" aria-label="Close Alert!!!" type="button"><i></i></button>`)
         : ''
     }
     ${
@@ -80,6 +89,8 @@ export const AlertRibbon = {
     link: 'part of the sentence.',
     button: false,
     primaryButton: '',
-    closeButton: true,
+    closeButton: false,
+    isCloseable: true,
+    closeText: 'Close this',
   },
 }

--- a/libs/react/src/lib/alert-ribbon/alert-ribbon.mdx
+++ b/libs/react/src/lib/alert-ribbon/alert-ribbon.mdx
@@ -71,6 +71,8 @@ Close button icon
 
 <Canvas of={AlertRibbonStories.DangerWithCloseButton} />
 
+<Canvas of={AlertRibbonStories.InfoWithCustomCloseButton} />
+
 
 ## AlertRibbon with Footer Buttons
 

--- a/libs/react/src/lib/alert-ribbon/alert-ribbon.stories.tsx
+++ b/libs/react/src/lib/alert-ribbon/alert-ribbon.stories.tsx
@@ -179,6 +179,20 @@ DangerWithCloseButton.args = {
   closeText: '',
 }
 
+export const InfoWithCustomCloseButton = Template.bind({})
+InfoWithCustomCloseButton.args = {
+  type: '',
+  header: 'Info',
+  footer: null,
+  children: (
+    <>
+      This is an alert type with a custom close label.
+    </>
+  ),
+  isCloseable: true,
+  closeText: 'Stäng',
+}
+
 export const InfoWithFooterButtons = Template.bind({})
 InfoWithFooterButtons.args = {
   type: '',

--- a/libs/react/src/lib/alert-ribbon/alert-ribbon.tsx
+++ b/libs/react/src/lib/alert-ribbon/alert-ribbon.tsx
@@ -35,15 +35,13 @@ export function AlertRibbon({
     } else {
       if (closeText)
         setCloseButton(
-          <button className="close">
-            <span className="sr-only">{closeText}</span>
+          <button className="close" aria-label={closeText}>
             <i></i>
           </button>,
         )
       else
         setCloseButton(
-          <button className="close">
-            <span className="sr-only">Close</span>
+          <button className="close" aria-label="Close">
             <i></i>
           </button>,
         )
@@ -85,7 +83,7 @@ export function AlertRibbon({
         <button
           className="close"
           type="button"
-          aria-label={closeAriaLabel ?? 'Close alert'}
+          aria-label={closeText ?? 'Close alert'}
           onClick={(event) => {
             onClose && onClose(event)
           }}


### PR DESCRIPTION
Both Chlorophyll and React close button now have custom label and shows up correctly in screen readers.

Check if closeText, isCloseable, closeAriaLabel & closeButton are correct.

Note: This is a remake and a split up of #1672.