### PR TITLE
Modal react close text fix

### DIFF
--- a/.changeset/afraid-spies-happen.md
+++ b/.changeset/afraid-spies-happen.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': patch
+---
+
+Modal react close button fix

--- a/libs/react/src/lib/modal/modal.spec.tsx
+++ b/libs/react/src/lib/modal/modal.spec.tsx
@@ -44,7 +44,7 @@ describe('Modal', () => {
   it('Should close modal with header close button click', () => {
     render(<MockModal />)
     expect(screen.getByText('This is a modal body')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('Close'))
+    fireEvent.click(screen.getByLabelText('Close Modal'))
     expect(screen.queryByText('This is a modal body')).toBe(null)
   })
 

--- a/libs/react/src/lib/modal/modal.stories.tsx
+++ b/libs/react/src/lib/modal/modal.stories.tsx
@@ -38,6 +38,7 @@ export const ModalDefault: Story<ModalProps> = Template.bind({})
 ModalDefault.args = {
   type: 'default',
   header: 'Default Modal',
+  closeText: 'Custom Close Label',
   children: 'Body content',
   confirm: 'OK',
   dismiss: 'Nope',
@@ -46,7 +47,8 @@ ModalDefault.args = {
 export const SlideOutSmall: Story<ModalProps> = Template.bind({})
 SlideOutSmall.args = {
   type: 'slideout',
-  header: 'SlideOut Modal',
+  header: 'SlideOut Modal - Small',
+  closeText: 'Custom Close Label',
   children: 'Body content',
   confirm: 'OK',
   dismiss: 'Nope',
@@ -56,7 +58,8 @@ SlideOutSmall.args = {
 export const SlideOutMedium: Story<ModalProps> = Template.bind({})
 SlideOutMedium.args = {
   type: 'slideout',
-  header: 'SlideOut Modal',
+  header: 'SlideOut Modal - Medium',
+  closeText: 'Custom Close Label',
   children: 'Body content',
   confirm: 'OK',
   dismiss: 'Nope',
@@ -66,7 +69,8 @@ SlideOutMedium.args = {
 export const SlideOutLarge: Story<ModalProps> = Template.bind({})
 SlideOutLarge.args = {
   type: 'slideout',
-  header: 'SlideOut Modal',
+  header: 'SlideOut Modal - Large',
+  closeText: 'Custom Close Label',
   children: 'Body content',
   confirm: 'OK',
   dismiss: 'Nope',
@@ -77,6 +81,7 @@ export const TakeOver: Story<ModalProps> = Template.bind({})
 TakeOver.args = {
   type: 'takeover',
   header: 'TakeOver Modal',
+  closeText: 'Custom Close Label',
   children: 'Body content',
   confirm: 'OK',
   dismiss: 'Nope',

--- a/libs/react/src/lib/modal/modal.tsx
+++ b/libs/react/src/lib/modal/modal.tsx
@@ -27,6 +27,7 @@ export interface ModalProps {
   children: ReactNode
   confirm?: string
   dismiss?: string
+  closeText?: string
   size?: Size
   id?: string
   isOpen?: boolean
@@ -37,7 +38,7 @@ export interface ModalProps {
 }
 
 interface ModalHeaderProps
-  extends Pick<ModalProps, 'type' | 'header' | 'id' | 'onClose'> {
+  extends Pick<ModalProps, 'type' | 'header' | 'closeText' | 'id' | 'onClose'> {
   setStatus?: (status: string) => void
   setShouldRender?: (shouldRender: boolean) => void
 }
@@ -47,6 +48,7 @@ const ModalHeader = ({
   setStatus,
   setShouldRender,
   header = '',
+  closeText = 'Close Modal',
   id,
   onClose,
 }: ModalHeaderProps) => {
@@ -67,8 +69,7 @@ const ModalHeader = ({
   return (
     <div className="header">
       <h3 id={id}>{header}</h3>
-      <button className="close" onClick={handleClose}>
-        <span className="sr-only">Close</span>
+      <button className="close" aria-label={ closeText } onClick={handleClose}>
         <i></i>
       </button>
     </div>


### PR DESCRIPTION
All modals for React can now have custom close button text for screen readers.
(Will do modal fix for Angular next)