### PR TITLE
Enable Color Tokens on Root using `gds-theme` attribute

### DIFF
--- a/.changeset/sharp-deers-poke.md
+++ b/.changeset/sharp-deers-poke.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': minor
+---
+
+**Core Tokens:** Enable light and dark mode tokens on root based on `gds-theme` attribute

--- a/libs/core/src/tokens.style.ts
+++ b/libs/core/src/tokens.style.ts
@@ -27,8 +27,12 @@ const tokens = [
 GlobalStylesRegistry.instance.injectGlobalStyles(
   'root-tokens',
   css`
-    :root {
+    :root,
+    :root[gds-theme='light'] {
       ${unsafeCSS(colorV2Light)}
+    }
+    :root[gds-theme='dark'] {
+      ${unsafeCSS(colorV2Dark)}
     }
   `,
 )


### PR DESCRIPTION

This pull request includes changes to the `libs/core/src/tokens.style.ts` file to enhance theme support by adding styles for both light and dark themes.

Enhancements to theme support:

* [`libs/core/src/tokens.style.ts`](diffhunk://#diff-88400f14e6d2f7007fc0593775702e608d3861c5a90331645d18410fb64b8933L30-R36): Added global styles for `:root[gds-theme='light']` and `:root[gds-theme='dark']` to support light and dark themes respectively.