### PR TITLE
Make bodyScrollLock optional in React modal

### DIFF
--- a/.changeset/heavy-fans-fry.md
+++ b/.changeset/heavy-fans-fry.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-react': minor
 ---
 
-**Modal:** Make bodyScrollLock optional through prop
+**Modal:** Make bodyScrollLock optional through prop. Fixes #1742

--- a/.changeset/heavy-fans-fry.md
+++ b/.changeset/heavy-fans-fry.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': minor
+---
+
+**Modal:** Make bodyScrollLock optional through prop

--- a/.changeset/rare-mails-live.md
+++ b/.changeset/rare-mails-live.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': minor
+---
+
+**Dropdown:** Expose `gds-ui-state` event through wrapper

--- a/libs/react/src/lib/dropdown/dropdown.tsx
+++ b/libs/react/src/lib/dropdown/dropdown.tsx
@@ -57,6 +57,8 @@ export interface DropdownArgs {
 
   /** Whether to disable the mobile styles */
   disableMobileStyles?: boolean
+
+  onGdsUiState?: (e: CustomEvent) => void
 }
 export interface DropdownTexts {
   placeholder?: string
@@ -74,7 +76,7 @@ registerTransitionalStyles()
 export const CoreDropdown = createComponent({
   tagName: getScopedTagName('gds-dropdown'),
   elementClass: GdsDropdown,
-  events: { onchange: 'change' },
+  events: { onChange: 'change', onGdsUiState: 'gds-ui-state' },
   react: React,
 })
 
@@ -105,6 +107,7 @@ export const Dropdown = ({
   value,
   syncPopoverWidth,
   disableMobileStyles,
+  onGdsUiState = () => {},
   ...props
 }: DropdownProps) => {
   const handleOnChange = (e: any) => {
@@ -133,7 +136,7 @@ export const Dropdown = ({
         label={label}
         searchable={searchable}
         multiple={multiSelect}
-        onchange={handleOnChange}
+        onChange={handleOnChange}
         invalid={validator?.indicator === 'error'}
         compareWith={compareWithAdapter}
         value={value}
@@ -143,6 +146,7 @@ export const Dropdown = ({
         hideLabel={props.hideLabel}
         maxHeight={props.maxHeight}
         disableMobileStyles={disableMobileStyles}
+        onGdsUiState={(e: Event) => onGdsUiState(e as CustomEvent)}
       >
         {informationLabel && <span slot="sub-label">{informationLabel}</span>}
         {validator && <span slot="message">{validator.message}</span>}

--- a/libs/react/src/lib/dropdown/dropdown.tsx
+++ b/libs/react/src/lib/dropdown/dropdown.tsx
@@ -58,6 +58,7 @@ export interface DropdownArgs {
   /** Whether to disable the mobile styles */
   disableMobileStyles?: boolean
 
+  /** Event handler for when the dropdown is opened or closed */
   onGdsUiState?: (e: CustomEvent) => void
 }
 export interface DropdownTexts {
@@ -107,7 +108,7 @@ export const Dropdown = ({
   value,
   syncPopoverWidth,
   disableMobileStyles,
-  onGdsUiState = () => {},
+  onGdsUiState,
   ...props
 }: DropdownProps) => {
   const handleOnChange = (e: any) => {
@@ -146,7 +147,7 @@ export const Dropdown = ({
         hideLabel={props.hideLabel}
         maxHeight={props.maxHeight}
         disableMobileStyles={disableMobileStyles}
-        onGdsUiState={(e: Event) => onGdsUiState(e as CustomEvent)}
+        onGdsUiState={(e: Event) => onGdsUiState?.(e as CustomEvent)}
       >
         {informationLabel && <span slot="sub-label">{informationLabel}</span>}
         {validator && <span slot="message">{validator.message}</span>}

--- a/libs/react/src/lib/modal/modal.tsx
+++ b/libs/react/src/lib/modal/modal.tsx
@@ -35,6 +35,7 @@ export interface ModalProps {
   onConfirm?: ModalEventListener
   onDismiss?: ModalEventListener
   preventBackdropClose?: boolean
+  enableBodyScrollLock?: boolean
 }
 
 interface ModalHeaderProps
@@ -69,7 +70,7 @@ const ModalHeader = ({
   return (
     <div className="header">
       <h3 id={id}>{header}</h3>
-      <button className="close" aria-label={ closeText } onClick={handleClose}>
+      <button className="close" aria-label={closeText} onClick={handleClose}>
         <i></i>
       </button>
     </div>
@@ -130,6 +131,7 @@ export const Modal = ({
   id = randomId(),
   isOpen,
   size = 'sm',
+  enableBodyScrollLock = true,
   ...props
 }: ModalProps) => {
   const [uuid, _] = useState(id)
@@ -158,8 +160,7 @@ export const Modal = ({
         setShouldRender(false)
       }, DELAY)
     }
-
-    if (isOpen && modalRef.current) {
+    if (isOpen && modalRef.current && enableBodyScrollLock) {
       // Disable scrolling on the body when the modal is open
       disableBodyScroll(modalRef.current)
     } else if (modalRef.current) {
@@ -171,7 +172,7 @@ export const Modal = ({
       // Cleanup by enabling body scroll and removing all scroll locks
       clearAllBodyScrollLocks()
     }
-  }, [isOpen, shouldRender, status])
+  }, [isOpen, shouldRender, status, enableBodyScrollLock])
 
   if (!isOpen) return null
 


### PR DESCRIPTION
This PR makes it possible to disable bodyScrollLock in modals. This is useful particularly on iOS, where the scroll lock can prevent scroll in undesired areas.

Related: #1742