### PR TITLE
Fix 2016 scss vars

### DIFF
--- a/.changeset/random-file-name.md
+++ b/.changeset/random-file-name.md
@@ -1,0 +1,7 @@
+---
+'@sebgroup/green-tokens': patch
+---
+
+**SCSS:** Fix dark mode variables for 2016
+
+**Colors:** Fix `dark-blue-1` for 2016

--- a/libs/tokens/src/formats.ts
+++ b/libs/tokens/src/formats.ts
@@ -374,6 +374,47 @@ const formats: Record<string, Format> = {
       )
     },
   },
+  'scss/variables': {
+    name: 'scss/variables',
+    formatter: function (args) {
+      const dictionary = Object.assign({}, args.dictionary)
+      const options = Object.assign(
+        { colorScheme: 'light' },
+        args.options,
+      )
+
+      const { colorScheme, name, outputReferences } = options
+
+      if (colorScheme === 'dark') {
+        // Override each token"s `value` with `darkValue`
+        dictionary.allTokens = dictionary.allTokens.map((token) => {
+          const { darkValue } = token
+          // Only override if the token has a darkValue and that you"ve passed in colorScheme: "dark" in the file options.
+          if (darkValue && colorScheme === 'dark') {
+            return Object.assign({}, token, {
+              value: token['darkValue'],
+              //Also need to override the original value for outputReferences: false to work
+              original: { value: token.original['darkValue'] },
+            })
+          } else {
+            return token
+          }
+        })
+      }
+
+      // Use the built-in format but with our customized dictionary object
+      // so it will output the darkValue instead of the value
+      // return format[format]({ ...args, dictionary })
+      return (
+        formatHelpers.fileHeader({ file: args.file }),
+        formatHelpers.formattedVariables({
+          format: 'sass',
+          dictionary,
+          outputReferences,
+        })
+      )
+    },
+  },
   'green/ios-swift-package': {
     name: 'green/ios-swift-package',
     formatter: function ({ options, file }) {

--- a/libs/tokens/src/tokens/2016/colors.json
+++ b/libs/tokens/src/tokens/2016/colors.json
@@ -262,8 +262,8 @@
         "version": "2016"
       },
       "dark-blue--1": {
-        "value": "{ref.color.blue-200}",
-        "darkValue": "{ref.color.blue-100}",
+        "value": "{ref.color.blue-500}",
+        "darkValue": "{ref.color.blue-300}",
         "type": "color",
         "version": "2016"
       },

--- a/libs/tokens/style-dictionary.config.ts
+++ b/libs/tokens/style-dictionary.config.ts
@@ -284,6 +284,7 @@ const config: StyleDictionary.Config = {
           filter: 'is2016Color',
           options: {
             outputReferences: false,
+            colorScheme: 'dark',
           },
         },
         {


### PR DESCRIPTION
In this PR:
- Add custom formatting for scss varaibles so that dark mode gets picked up correctly
- Correct color value for `dark-blue-1`