### PR TITLE
Add concept documentation about tokens

### DIFF
--- a/.changeset/fuzzy-bulldogs-dream.md
+++ b/.changeset/fuzzy-bulldogs-dream.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**GdsTheme:** Fix issue with changing `color-scheme`

--- a/.changeset/wild-stingrays-swim.md
+++ b/.changeset/wild-stingrays-swim.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': minor
+---
+
+**GdsTheme:** Include all 2023 CSS variables instead of only colors

--- a/libs/core/src/components/theme/theme.test.ts
+++ b/libs/core/src/components/theme/theme.test.ts
@@ -16,12 +16,13 @@ describe('GdsTheme', () => {
       const element = await fixture<GdsTheme>(html`<gds-theme></gds-theme>`)
       await element.updateComplete
 
-      expect(element._dynamicStylesController.has('light')).to.be.true
-
       element.colorScheme = 'dark'
       await element.updateComplete
 
-      expect(element._dynamicStylesController.has('dark')).to.be.true
+      expect(element._dynamicStylesController.has('color-scheme')).to.be.true
+      expect(window.getComputedStyle(element).colorScheme).to.have.string(
+        'dark',
+      )
     })
 
     it('should dispatch an event when setting `designVersion`', async () => {

--- a/libs/core/src/components/theme/theme.ts
+++ b/libs/core/src/components/theme/theme.ts
@@ -3,7 +3,7 @@ import { property } from 'lit/decorators.js'
 
 import { GdsElement } from '../../gds-element'
 import { gdsCustomElement, html } from '../../scoping'
-import { colorV2Dark, colorV2Light } from '../../tokens.style'
+import { colorV2Dark, colorV2Light, tokens } from '../../tokens.style'
 import { TransitionalStyles } from '../../transitional-styles'
 import { watch } from '../../utils/decorators'
 
@@ -23,11 +23,14 @@ import { watch } from '../../utils/decorators'
  */
 @gdsCustomElement('gds-theme')
 export class GdsTheme extends GdsElement {
-  static styles = css`
-    :host {
-      display: contents;
-    }
-  `
+  static styles = [
+    tokens,
+    css`
+      :host {
+        display: contents;
+      }
+    `,
+  ]
   /**
    * The theme mode. Can be `light`, `dark`, or `auto`.
    */
@@ -58,12 +61,12 @@ export class GdsTheme extends GdsElement {
   private _onColorSchemeChange() {
     if (this.colorScheme === 'dark') {
       this._dynamicStylesController.inject(
-        'dark',
+        'color-scheme',
         unsafeCSS(`:host { ${colorV2Dark}}`),
       )
     } else {
       this._dynamicStylesController.inject(
-        'light',
+        'color-scheme',
         unsafeCSS(`:host { ${colorV2Light}}`),
       )
     }

--- a/libs/core/src/storybook-docs/concepts/tokens.mdx
+++ b/libs/core/src/storybook-docs/concepts/tokens.mdx
@@ -70,4 +70,4 @@ Here is an example of using the theme component to get access to variables:
 </gds-theme>
 ```
 
-Try inspecting this example in Chrome DevTool, and change the value of the `color-scheme` attribute in the `<gds-theme>` element to `dark` to see what happens to the color variables.
+Try inspecting this example in Chrome DevTools, and change the value of the `color-scheme` attribute in the `<gds-theme>` element to `dark` to see what happens to the color variables.

--- a/libs/core/src/storybook-docs/concepts/tokens.mdx
+++ b/libs/core/src/storybook-docs/concepts/tokens.mdx
@@ -1,0 +1,70 @@
+import { Meta, Markdown } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Tokens" />
+
+# Tokens
+
+Green Design System uses a token-based approach to design. This means
+that design properties, such as colors and spacing values, are defined
+in a single place and are then used throughout the design system.
+This makes it easier to maintain and update the design system and helps to
+ensure consistency across the components in the system and the products
+that use them.
+
+Tokens are  commonly reffered to as <em>variables</em>, and these terms
+can be used interchangeably for the most parts. The distiction is mainly an
+abstract one, with the term <em>token</em> meaning the design value itself,
+whereas <em>variable</em> often refers to the concrete implementation in code. In
+CSS it is typically called `variables` though the technically correct terminlogy
+is `CSS custom properties`. In Figma, they are called `variables`. Other
+languagues and tools may have other names for the same concept.
+
+## Token collections
+
+Tokens in Green are grouped in the following collections:
+
+- Colors\
+  Green uses a three-level color system, which you can read more about under [Style/Colors](/docs/style-colors--docs)
+- Text\
+  Text tokens include font sizes, line heights, and font weights. Read more under [Style/Typography](/docs/style-typography--docs)
+- Sizes\
+  Size tokens define the spacing values used for paddings, margins, gaps and other spaces in the design. Read more under [Style/Size](/docs/style-size--docs)
+- Viewports\
+  Viewport tokens define the breakpoints used in the design system.
+- Shadows\
+  Shadow tokens define the `box-shadow` values used in the design system.
+
+## Using token variables
+
+In most cases you don't need to use variables directly. They are already used in
+the design of the components, and if you are using [Declarative Layout](/docs/concepts-declarative-layout--docs), you have a
+simplified way of using the tokens. You can read more on this under [Style/Colors](/docs/style-colors--docs).
+
+However, in some cases you will need to use CSS variables directly in your code, so
+let's briefly go over how to access them.
+
+### Using the CSS variables
+
+In CSS, you can access the tokens by using the `var()` function. If you are not familiar
+with CSS variables, you can [read more about them on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+
+By default, tokens are registered on the `:host` selector of every component, so in order to access them, the element you are styling
+needs to be a child to a Green component. If a parent of your element is one of the declarative layout components for Green
+(ie, container, flex, grid or card), you're already covered, but if not, you can use `<gds-theme>` for this purpose. `<gds-theme>` does not
+add any visible layout to the page, but it provides access to all the CSS variables. The theme component can also be used to toggle
+between light and dark mode, as well as setting the design version to be used by its descendants. You can [read more about the theme component here](/docs/components-theme--docs).
+
+Here is an example of using the theme component to get access to variables:
+
+<gds-theme design-version="2023">
+  <div style={{backgroundColor: `var(--gds-color-l2-background-primary)`, color: `var(--gds-color-l2-content-primary)`, padding: `var(--gds-space-l)`}}>Hello world</div>
+</gds-theme>
+```html
+<gds-theme design-version="2023">
+  <div style="background-color: var(--gds-color-l2-background-primary); color: var(--gds-color-l2-content-primary); padding: var(--gds-space-l);">
+    Hello world
+  </div>
+</gds-theme>
+```
+
+Try inspecting this example in Chrome DevTool, and change the value of the `color-scheme` attribute in the `<gds-theme>` element to `dark` to see what happens to the color variables.

--- a/libs/core/src/storybook-docs/concepts/tokens.mdx
+++ b/libs/core/src/storybook-docs/concepts/tokens.mdx
@@ -11,7 +11,7 @@ This makes it easier to maintain and update the design system and helps to
 ensure consistency across the components in the system and the products
 that use them.
 
-Tokens are  commonly reffered to as <em>variables</em>, and these terms
+Tokens are  commonly referred to as <em>variables</em>, and these terms
 can be used interchangeably for the most parts. The distiction is mainly an
 abstract one, with the term <em>token</em> meaning the design value itself,
 whereas <em>variable</em> often refers to the concrete implementation in code. In
@@ -48,8 +48,11 @@ let's briefly go over how to access them.
 In CSS, you can access the tokens by using the `var()` function. If you are not familiar
 with CSS variables, you can [read more about them on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 
-By default, tokens are registered on the `:host` selector of every component, so in order to access them, the element you are styling
-needs to be a child to a Green component. If a parent of your element is one of the declarative layout components for Green
+By default, tokens are defined on the `:host` selector of every component, so in order to access them, the element you are styling
+needs to be a child to a Green component. CSS variables, as opposed to other CSS properties, propagates down across shadow DOM boundaries,
+so when they are defined on the `:host` selector of a component, they are available to all children of that component.
+
+If a parent of your element is one of the declarative layout components from Green
 (ie, container, flex, grid or card), you're already covered, but if not, you can use `<gds-theme>` for this purpose. `<gds-theme>` does not
 add any visible layout to the page, but it provides access to all the CSS variables. The theme component can also be used to toggle
 between light and dark mode, as well as setting the design version to be used by its descendants. You can [read more about the theme component here](/docs/components-theme--docs).

--- a/libs/core/src/storybook-docs/style/colors.mdx
+++ b/libs/core/src/storybook-docs/style/colors.mdx
@@ -170,14 +170,14 @@ The color system is divided into three levels:
     </gds-container>
   </gds-flex>
 
-  ## Working with the color system and Declarative Layout
+  ## Working with the color system and [Declarative Layout](/docs/concepts-declarative-layout--docs)
 
   Components in Green will automatically use color value from the appropriate level
   for that component, based on the type of the component. However, nesting levels in the DOM
   will not automatically affect the color level. For example, nesting a card inside another
   card will still use the level 2 color for the inner card by default.
 
-  When using the declarative layout system in Green, you will typically only need to
+  When using the [declarative layout](/docs/concepts-declarative-layout--docs) system in Green, you will typically only need to
   set the color variant. The exact color value will get resolved automatically.
 
   For example, setting the background property of a `<gds-card>` will select the

--- a/libs/core/src/storybook-docs/style/colors.mdx
+++ b/libs/core/src/storybook-docs/style/colors.mdx
@@ -218,7 +218,7 @@ The color system is divided into three levels:
                                                 border-radius="xs"
                                                 border-width="4xs"
                                                 border-color="#d7d7d7"
-                                                background={item}
+                                                style={{background: `var(--gds-color-${level}-${category}-${item}`}}
                                                 padding="0"
                                             />
                                             <gds-flex flex-direction="column" gap="3xs" align-items="start">

--- a/libs/core/src/storybook-docs/style/colors.mdx
+++ b/libs/core/src/storybook-docs/style/colors.mdx
@@ -54,22 +54,22 @@ The color system is divided into three levels:
         flex-direction="column"
         gap="s"
       >
-        <gds-flex align-items="center" gap="xs">
-          <gds-icon-square-behind-square></gds-icon-square-behind-square>
+        <gds-button rank="secondary" onclick="let cb = document.getElementById('explode'); cb.checked = !cb.checked">
+          <gds-icon-square-behind-square slot="lead"></gds-icon-square-behind-square>
           <label htmlFor="explode">Exploded View</label>
-        </gds-flex>
-        <gds-flex align-items="center" gap="xs">
-          <gds-icon-focus-square></gds-icon-focus-square>
+        </gds-button>
+        <gds-button rank="secondary" onclick="let cb = document.getElementById('video'); cb.checked = !cb.checked">
+          <gds-icon-focus-square slot="lead"></gds-icon-focus-square>
           <label htmlFor="video">Reveal Background</label>
-        </gds-flex>
-        <gds-flex align-items="center" gap="xs">
-          <gds-icon-eye-slash></gds-icon-eye-slash>
+        </gds-button>
+        <gds-button rank="secondary" onclick="let cb = document.getElementById('hide'); cb.checked = !cb.checked">
+          <gds-icon-eye-slash slot="lead"></gds-icon-eye-slash>
           <label htmlFor="hide">Hide Video</label>
-        </gds-flex>
-        <gds-flex align-items="center" gap="xs">
-          <gds-icon-square-placeholder></gds-icon-square-placeholder>
+        </gds-button>
+        <gds-button rank="secondary" onclick="let cb = document.getElementById('mask'); cb.checked = !cb.checked">
+          <gds-icon-square-placeholder slot="lead"></gds-icon-square-placeholder>
           <label htmlFor="mask">Mask</label>
-        </gds-flex>
+        </gds-button>
     </gds-flex>
 
       <input type="checkbox" id="explode" name="explode" />

--- a/libs/core/src/storybook-docs/style/colors.mdx
+++ b/libs/core/src/storybook-docs/style/colors.mdx
@@ -170,7 +170,7 @@ The color system is divided into three levels:
     </gds-container>
   </gds-flex>
 
-  ## Working with the color system
+  ## Working with the color system and Declarative Layout
 
   Components in Green will automatically use color value from the appropriate level
   for that component, based on the type of the component. However, nesting levels in the DOM

--- a/libs/core/src/storybook-docs/style/colors.mdx
+++ b/libs/core/src/storybook-docs/style/colors.mdx
@@ -25,220 +25,250 @@ import VIDEO from './video.mp4'
 # Color System
 The color system is a collection of colors that are used to create a visual hierarchy in the green design system.
 
-### The color system is divided into three levels:
+### Color levels
 
-<gds-flex flex-direction="column" gap="l" >
-  <gds-flex gap="s">
-    <gds-badge>L1: Document</gds-badge>
-    <gds-badge variant="notice">L2: Container</gds-badge>
-    <gds-badge variant="positive">L3: Component</gds-badge>
-  </gds-flex>
+The color system is divided into three levels:
 
-  <gds-container
-    display="grid"
-    place-items="center"
-    min-height="80vh"
-    border-radius="s"
-    level="1"
-    background="secondary"
-    position="relative"
-  >
-    <gds-flex
-      position="absolute"
-      inset="20px auto auto 20px"
-      flex-direction="column"
-      gap="s"
-    >
-      <gds-flex align-items="center" gap="xs">
-        <gds-icon-square-behind-square></gds-icon-square-behind-square>
-        <label htmlFor="explode">Exploded View</label>
-      </gds-flex>
-      <gds-flex align-items="center" gap="xs">
-        <gds-icon-focus-square></gds-icon-focus-square>
-        <label htmlFor="video">Reveal Background</label>
-      </gds-flex>
-      <gds-flex align-items="center" gap="xs">
-        <gds-icon-eye-slash></gds-icon-eye-slash>
-        <label htmlFor="hide">Hide Video</label>
-      </gds-flex>
-      <gds-flex align-items="center" gap="xs">
-        <gds-icon-square-placeholder></gds-icon-square-placeholder>
-        <label htmlFor="mask">Mask</label>
-      </gds-flex>
-  </gds-flex>
-
-    <input type="checkbox" id="explode" name="explode" />
-    <input type="checkbox" id="video" name="video" />
-    <input type="checkbox" id="hide" name="hide" />
-    <input type="checkbox" id="mask" name="mask" />
-    <gds-flex
-      level="1"
-      class="gds-levels"
-      transform-style="preserve-3d"
-      background="primary"
-      data-title="L1: Document"
-      width="400px"
-      height="80%"
-      position="relative"
-      border-radius="l"
-    >
-
-    <gds-container
-      level="2"
-      border="xs/inversed"
-      border-radius="l"
-      style={{transform: 'translate3d(0, 0, 100px)'}}
-      background="positive"
-      data-title="L2: Container"
-      position="absolute"
-      inset="0"
-    >
-      <gds-container
-        inset="0"
-        overflow="hidden"
-        position="absolute"
-        border-radius="m"
-        id="cover"
-      >
-        <gds-video
-          src={VIDEO}
-          object-fit="cover"
-          object-position="center"
-          aspect-ratio="9/16"
-          pointer-events="none"
-          autoplay
-          muted
-          loop
-          ></gds-video>
-      </gds-container>
-    </gds-container>
-
-    <gds-container
-      border-radius="s"
-      style={{transform: 'translate3d(0, 0, 200px)'}}
-      data-title="L3: Component"
-      position="absolute"
-      inset="0"
-      margin="xs"
-    >
-
-          <gds-mask
-            id="masker"
-            mask-image="top"
-            background-color="tertiary/0.6"
-            position="absolute"
-            backdrop-filter="blur(4px)"
-            overflow="hidden"
-            border-radius="m"
-          >
-            <gds-flex
-              flex-direction="column"
-              justify-content="flex-end"
-              padding="4xl 2xl 2xl 2xl"
-              gap="l"
-              height="100%"
-              width="100%"
-              color="tertiary"
-            >
-              <gds-container>
-                <gds-text tag="h3" text-wrap="balance">Sustainable Practices</gds-text>
-
-                <gds-text
-                  color="tertiary/0.6"
-                  font-size="body-s"
-                  >Promoting Eco-Friendly Solutions</gds-text>
-              </gds-container>
-              <gds-divider opacity="0.1"></gds-divider>
-              <gds-flex gap="s">
-                <gds-button rank="secondary">Get Involved</gds-button>
-                <gds-theme color-scheme="dark">
-                  <gds-button rank="tertiary">Learn more</gds-button>
-                </gds-theme>
-              </gds-flex>
-            </gds-flex>
-          </gds-mask>
-
-
-    </gds-container>
-
+<gds-theme design-version="2023">
+  <gds-flex flex-direction="column" gap="l" margin="0 0 l">
+    <gds-flex gap="s" flex-direction="column">
+      <gds-flex gap="s"><gds-badge>L1: Document</gds-badge> Document background</gds-flex>
+      <gds-flex padding="0 0 0 m" gap="s"><gds-badge variant="notice">L2: Container</gds-badge> Containers, such as cards and popovers</gds-flex>
+      <gds-flex padding="0 0 0 xl" gap="s"><gds-badge variant="positive">L3: Component</gds-badge> Components, such as buttons, form controls and badges</gds-flex>
     </gds-flex>
-  </gds-container>
-</gds-flex>
+
+    Here's an interactive example to illustrate the concept:
+
+    <gds-container
+      display="grid"
+      place-items="center"
+      min-height="80vh"
+      border-radius="s"
+      level="1"
+      background="secondary"
+      position="relative"
+    >
+      <gds-flex
+        position="absolute"
+        inset="20px auto auto 20px"
+        flex-direction="column"
+        gap="s"
+      >
+        <gds-flex align-items="center" gap="xs">
+          <gds-icon-square-behind-square></gds-icon-square-behind-square>
+          <label htmlFor="explode">Exploded View</label>
+        </gds-flex>
+        <gds-flex align-items="center" gap="xs">
+          <gds-icon-focus-square></gds-icon-focus-square>
+          <label htmlFor="video">Reveal Background</label>
+        </gds-flex>
+        <gds-flex align-items="center" gap="xs">
+          <gds-icon-eye-slash></gds-icon-eye-slash>
+          <label htmlFor="hide">Hide Video</label>
+        </gds-flex>
+        <gds-flex align-items="center" gap="xs">
+          <gds-icon-square-placeholder></gds-icon-square-placeholder>
+          <label htmlFor="mask">Mask</label>
+        </gds-flex>
+    </gds-flex>
+
+      <input type="checkbox" id="explode" name="explode" />
+      <input type="checkbox" id="video" name="video" />
+      <input type="checkbox" id="hide" name="hide" />
+      <input type="checkbox" id="mask" name="mask" />
+      <gds-flex
+        level="1"
+        class="gds-levels"
+        transform-style="preserve-3d"
+        background="primary"
+        data-title="L1: Document"
+        width="400px"
+        height="80%"
+        position="relative"
+        border-radius="l"
+      >
+
+      <gds-container
+        level="2"
+        border="xs/inversed"
+        border-radius="l"
+        style={{transform: 'translate3d(0, 0, 100px)'}}
+        background="positive"
+        data-title="L2: Container"
+        position="absolute"
+        inset="0"
+      >
+        <gds-container
+          inset="0"
+          overflow="hidden"
+          position="absolute"
+          border-radius="m"
+          id="cover"
+        >
+          <gds-video
+            src={VIDEO}
+            object-fit="cover"
+            object-position="center"
+            aspect-ratio="9/16"
+            pointer-events="none"
+            autoplay
+            muted
+            loop
+            ></gds-video>
+        </gds-container>
+      </gds-container>
+
+      <gds-container
+        border-radius="s"
+        style={{transform: 'translate3d(0, 0, 200px)'}}
+        data-title="L3: Component"
+        position="absolute"
+        inset="0"
+        margin="xs"
+      >
+
+            <gds-mask
+              id="masker"
+              mask-image="top"
+              background-color="tertiary/0.6"
+              position="absolute"
+              backdrop-filter="blur(4px)"
+              overflow="hidden"
+              border-radius="m"
+            >
+              <gds-flex
+                flex-direction="column"
+                justify-content="flex-end"
+                padding="4xl 2xl 2xl 2xl"
+                gap="l"
+                height="100%"
+                width="100%"
+                color="tertiary"
+              >
+                <gds-container>
+                  <gds-text tag="h3" text-wrap="balance">Sustainable Practices</gds-text>
+
+                  <gds-text
+                    color="tertiary/0.6"
+                    font-size="body-s"
+                    >Promoting Eco-Friendly Solutions</gds-text>
+                </gds-container>
+                <gds-divider opacity="0.1"></gds-divider>
+                <gds-flex gap="s">
+                  <gds-button rank="secondary">Get Involved</gds-button>
+                  <gds-theme color-scheme="dark" design-version="2023">
+                    <gds-button rank="tertiary">Learn more</gds-button>
+                  </gds-theme>
+                </gds-flex>
+              </gds-flex>
+            </gds-mask>
 
 
-# Colors
-<gds-flex flex-direction="column" gap="2xl">
-  {Object.entries(colors.color.level).map(([level, categories]) => (
-      <gds-flex flex-direction="column" gap="2xl">
-        <gds-flex gap="s" flex-direction="column">
-          <gds-text text-transform="uppercase">{level}</gds-text>
-            {Object.entries(categories).map(([category, items]) => (
-                <gds-flex gap="s" flex-direction="column">
-                    <gds-text text-transform="capitalize"
-                    level="1" color="primary/0.4">{category}</gds-text>
-                    <gds-flex flex-direction="row" gap="s">
-                        {Object.entries(items).map(([item, properties]) => (
-                            <gds-flex flex-direction="column" gap="s">
-                                  <gds-theme color-scheme="auto">
-                                    <gds-card border="4xs/primary" background="primary" border-radius="s" padding="xs" width="20ch">
-                                        <gds-flex gap="xs" align-items="center" >
-                                          <gds-card
-                                              level={level.replace(/^l/, '')}
-                                              height="40px"
-                                              width="40px"
-                                              border-radius="xs"
-                                              border-width="4xs"
-                                              border-color="#d7d7d7"
-                                              background={item}
-                                              padding="0"
-                                          />
-                                          <gds-flex flex-direction="column" gap="3xs" align-items="start">
-                                              <gds-text tag="small">{item}</gds-text>
-                                              <gds-text text-transform="uppercase">{properties.value}</gds-text>
+      </gds-container>
+
+      </gds-flex>
+    </gds-container>
+  </gds-flex>
+
+  ## Working with the color system
+
+  Components in Green will automatically use color value from the appropriate level
+  for that component, based on the type of the component. However, nesting levels in the DOM
+  will not automatically affect the color level. For example, nesting a card inside another
+  card will still use the level 2 color for the inner card by default.
+
+  When using the declarative layout system in Green, you will typically only need to
+  set the color variant. The exact color value will get resolved automatically.
+
+  For example, setting the background property of a `<gds-card>` will select the
+  corresponding level 2 background color. L2, since cards are considered containers,
+  and `background`, since that's the property that was used.
+
+  ```html
+  <gds-card background="primary">Will resolve to `--gds-color-l2-background-primary`</gds-card>
+  ```
+
+  If necessary, you can also explicitly declare which level you want to use by setting
+  the `level` attribute on the component.
+
+  ```html
+  <gds-card level="3" background="primary">Will resolve to `--gds-color-l3-background-primary`</gds-card>
+  ```
+
+  ## Colors
+  <gds-flex flex-direction="column" gap="2xl">
+    {Object.entries(colors.color.level).map(([level, categories]) => (
+        <gds-flex flex-direction="column" gap="2xl">
+          <gds-flex gap="s" flex-direction="column">
+            <gds-text text-transform="uppercase">{level}</gds-text>
+              {Object.entries(categories).map(([category, items]) => (
+                  <gds-flex gap="s" flex-direction="column">
+                      <gds-text text-transform="capitalize"
+                      level="1" color="primary/0.4">{category}</gds-text>
+                      <gds-flex flex-direction="row" gap="s">
+                          {Object.entries(items).map(([item, properties]) => (
+                              <gds-flex flex-direction="column" gap="s">
+                                    <gds-theme color-scheme="auto">
+                                      <gds-card border="4xs/primary" background="primary" border-radius="s" padding="xs" width="20ch">
+                                          <gds-flex gap="xs" align-items="center" >
+                                            <gds-card
+                                                level={level.replace(/^l/, '')}
+                                                height="40px"
+                                                width="40px"
+                                                border-radius="xs"
+                                                border-width="4xs"
+                                                border-color="#d7d7d7"
+                                                background={item}
+                                                padding="0"
+                                            />
+                                            <gds-flex flex-direction="column" gap="3xs" align-items="start">
+                                                <gds-text tag="small">{item}</gds-text>
+                                                <gds-text text-transform="uppercase">{properties.value}</gds-text>
+                                            </gds-flex>
                                           </gds-flex>
+                                      </gds-card>
+                                    </gds-theme>
+                                  <gds-theme color-scheme="dark">
+                                    <gds-card border="4xs/primary" background="primary" border-radius="s" padding="xs" width="20ch">
+                                        <gds-flex gap="xs" align-items="center" justify-content="start">
+                                            <gds-card
+                                                level={level.replace(/^l/, '')}
+                                                height="40px"
+                                                width="40px"
+                                                border-radius="xs"
+                                                border-width="4xs"
+                                                border-color="#3c3b3b"
+                                                background={item}
+                                                padding="0"
+                                            />
+                                            <gds-flex flex-direction="column" gap="3xs" align-items="start">
+                                              <gds-text
+                                                level="1"
+                                                color="primary"
+                                                tag="small"
+                                              >
+                                                {item}
+                                              </gds-text>
+                                              <gds-text
+                                                level="1"
+                                                color="primary"
+                                                tag="small"
+                                                transform="uppercase"
+                                              >
+                                                {properties.darkValue}
+                                              </gds-text>
+                                            </gds-flex>
                                         </gds-flex>
                                     </gds-card>
                                   </gds-theme>
-                                <gds-theme color-scheme="dark">
-                                  <gds-card border="4xs/primary" background="primary" border-radius="s" padding="xs" width="20ch">
-                                      <gds-flex gap="xs" align-items="center" justify-content="start">
-                                          <gds-card
-                                              level={level.replace(/^l/, '')}
-                                              height="40px"
-                                              width="40px"
-                                              border-radius="xs"
-                                              border-width="4xs"
-                                              border-color="#3c3b3b"
-                                              background={item}
-                                              padding="0"
-                                          />
-                                          <gds-flex flex-direction="column" gap="3xs" align-items="start">
-                                            <gds-text
-                                              level="1"
-                                              color="primary"
-                                              tag="small"
-                                            >
-                                              {item}
-                                            </gds-text>
-                                            <gds-text
-                                              level="1"
-                                              color="primary"
-                                              tag="small"
-                                              transform="uppercase"
-                                            >
-                                              {properties.darkValue}
-                                            </gds-text>
-                                          </gds-flex>
-                                      </gds-flex>
-                                  </gds-card>
-                                </gds-theme>
-                            </gds-flex>
-                        ))}
-                    </gds-flex>
-                </gds-flex>
-            ))}
+                              </gds-flex>
+                          ))}
+                      </gds-flex>
+                  </gds-flex>
+              ))}
+          </gds-flex>
         </gds-flex>
-      </gds-flex>
-    )
-  )}
-</gds-flex>
+      )
+    )}
+  </gds-flex>
+</gds-theme>


### PR DESCRIPTION
This PR adds a Tokens section under Concepts, and also fleshes out the Colors documentation a bit more.

It also includes som fixes to GdsTheme:
- Fix a bug where light-mode variables remained when switching to dark mode
- Add the rest of the tokens. Previously `GdsTheme` only included color tokens. Check the new Tokens doc to see why this is useful.