### PR TITLE
Datepicker label height fix

### DIFF
--- a/.changeset/light-queens-kiss.md
+++ b/.changeset/light-queens-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+Fix datepicker label lineheight

--- a/.changeset/light-queens-kiss.md
+++ b/.changeset/light-queens-kiss.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-core': patch
 ---
 
-Fix datepicker label lineheight
+**Datepicker:** Fix label line-height in transitional styles

--- a/libs/core/src/components/datepicker/datepicker.trans.styles.scss
+++ b/libs/core/src/components/datepicker/datepicker.trans.styles.scss
@@ -14,6 +14,7 @@
     display: block;
     font-weight: 500;
     margin-bottom: 0.5rem;
+    line-height: 1.25rem;
   }
 
   label + .field {


### PR DESCRIPTION
Line height set to 20px for both react and angular, just like the design have it.
Fixes: #1609