### PR TITLE
Fix chlorophyll storybook

### DIFF
--- a/libs/chlorophyll/.storybook/preview.ts
+++ b/libs/chlorophyll/.storybook/preview.ts
@@ -1,2 +1,15 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import '../../../.storybook/preview'
+
+const preview = {
+  parameters: {
+    options: {
+      storySort: {
+        method: 'alphabetical',
+        order: ['Introduction', 'How to use Cholorophyll'],
+      },
+    },
+  },
+}
+
+export default preview

--- a/libs/chlorophyll/stories/introduction/how-to-use.mdx
+++ b/libs/chlorophyll/stories/introduction/how-to-use.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/blocks'
 
 <Meta title="How to use Cholorophyll" />
 
-# Use
+# How to use Chlorophyll
 
 It's generally not recommended to use Chlorophyll directly. Instead you should use one of Greens component libraries which provides pre-made components for Angular and React.
 

--- a/libs/chlorophyll/stories/introduction/intro.mdx
+++ b/libs/chlorophyll/stories/introduction/intro.mdx
@@ -2,14 +2,39 @@ import { Meta } from '@storybook/blocks'
 
 <Meta title="Introduction" />
 
-# Welcome to Green
+# Introduction
 
-Green is an opinionated design system for building content and functionality for SEB.
+Green Design System is an opinionated design system for building content and functionality for SEB.
 It builds on a set of principles and techniques aimed at maximizing code quality, code reuse, consistency and collaboration.
+
+## This Storybook
+
+This storybook is to document how the components in Green are styled with Chlorophyll.
+
+<table>
+<thead>
+<tr>
+<th>Technology / Framework</th>
+<th>Storybook</th>
+<th>Package name</th>
+<th></th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>SCSS/CSS</td>
+<td>[Storybook Chlorophyll (This storybook)](https://storybook.seb.io/latest/chlorophyll/)</td>
+<td><a href="https://github.com/seb-oss/green/tree/main/libs/chlorophyll">@sebgroup/chlorophyll</a></td>
+<td><a href="https://github.com/seb-oss/green/tree/main/libs/chlorophyll/CHANGELOG.md">Changelog</a></td>
+<td>Styling framework</td>
+</tr>
+</tbody>
+</table>
 
 ## Getting started
 
-To get started with Green, you need to install the Green package for your framework of choice.
+To get started with Green, you need to install the Green package for your framework of choice. See supported frameworks below.
 
 ## Supported frameworks
 
@@ -46,13 +71,6 @@ Green provide a framework-agnostic core library of web components, as well as fr
 <td><a href="https://github.com/seb-oss/green/tree/main/libs/angular">@sebgroup/green-angular</a></td>
 <td><a href="https://github.com/seb-oss/green/tree/main/libs/angular/CHANGELOG.md">Changelog</a></td>
 <td>Angular component library</td>
-</tr>
-<tr>
-<td>CSS</td>
-<td>[Storybook Chlorophyll](https://storybook.seb.io/latest/chlorophyll/)</td>
-<td><a href="https://github.com/seb-oss/green/tree/main/libs/chlorophyll">@sebgroup/chlorophyll</a></td>
-<td><a href="https://github.com/seb-oss/green/tree/main/libs/chlorophyll/CHANGELOG.md">Changelog</a></td>
-<td>Styling framework</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
This PR contains a fix to show the first story in the chlorophyll storybook instead of Accordion docs as well as some updated docs.