### PR TITLE
fix: wrap dialog with wrapper element

### DIFF
--- a/libs/angular/src/v-angular/modal/dialog/dialog.component.html
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.component.html
@@ -1,60 +1,66 @@
-<div
-  class="modal-dialog__container"
-  *transloco="let t"
-  #dialog
-  role="dialog"
-  aria-dialog="true"
-  [attr.aria-labelledby]="dialogTitleId"
-  [attr.aria-describedby]="dialogBodyId"
->
-  <header class="modal-dialog__heading">
-    <h3 [attr.id]="dialogTitleId">{{ t(heading || title || '') }}</h3>
-    <button
-      data-thook="dialog-close"
-      (click)="onAction($event, 'close')"
-      (keydown.enter)="onAction($event, 'close')"
-      [attr.aria-label]="closeButtonAriaLabel"
-      class="nggv-modal-slideout__close"
+<ng-container *ngIf="shown">
+  <div
+    class="modal-dialog__wrapper"
+    [class.-active]="shown"
+  >
+    <div
+      class="modal-dialog__container"
+      *transloco="let t"
+      #dialog
+      role="dialog"
+      aria-dialog="true"
+      [attr.aria-labelledby]="dialogTitleId"
+      [attr.aria-describedby]="dialogBodyId"
     >
-      <i></i>
-    </button>
-  </header>
-  <section class="modal-dialog__body" [attr.id]="dialogBodyId">
-    <div [innerHtml]="content"></div>
-    <ng-content></ng-content>
-  </section>
-  <footer class="modal-dialog__actions">
-    <button
-      class="danger"
-      type="reset"
-      [attr.data-thook]="'dialog-' + (_buttons?.negative || 'negative')"
-      (click)="onAction($event, 'negative')"
-      (keydown.enter)="onAction($event, 'negative')"
-      *ngIf="_buttons && _buttons.negative"
-    >
-      {{ t(_buttons.negative) }}
-    </button>
-    <button
-      class="secondary"
-      type="button"
-      [attr.data-thook]="'dialog-' + (_buttons?.neutral || 'neutral')"
-      (click)="onAction($event, 'neutral')"
-      (keydown.enter)="onAction($event, 'neutral')"
-      *ngIf="_buttons && _buttons.neutral"
-    >
-      {{ t(_buttons.neutral) }}
-    </button>
-    <button
-      class="submit"
-      type="submit"
-      [attr.data-thook]="'dialog-' + (_buttons?.positive || 'positive')"
-      (click)="onAction($event, 'positive')"
-      (keydown.enter)="onAction($event, 'positive')"
-      *ngIf="_buttons && _buttons.positive"
-    >
-      {{ t(_buttons.positive) }}
-    </button>
-  </footer>
-</div>
-
-<div class="nggv-backdrop"></div>
+      <header class="modal-dialog__heading">
+        <h3 [attr.id]="dialogTitleId">{{ t(heading || title || '') }}</h3>
+        <button
+          data-thook="dialog-close"
+          (click)="onAction($event, 'close')"
+          (keydown.enter)="onAction($event, 'close')"
+          [attr.aria-label]="closeButtonAriaLabel"
+          class="nggv-modal-slideout__close"
+        >
+          <i></i>
+        </button>
+      </header>
+      <section class="modal-dialog__body" [attr.id]="dialogBodyId">
+        <div [innerHtml]="content"></div>
+        <ng-content></ng-content>
+      </section>
+      <footer class="modal-dialog__actions">
+        <button
+          class="danger"
+          type="reset"
+          [attr.data-thook]="'dialog-' + (_buttons?.negative || 'negative')"
+          (click)="onAction($event, 'negative')"
+          (keydown.enter)="onAction($event, 'negative')"
+          *ngIf="_buttons && _buttons.negative"
+        >
+          {{ t(_buttons.negative) }}
+        </button>
+        <button
+          class="secondary"
+          type="button"
+          [attr.data-thook]="'dialog-' + (_buttons?.neutral || 'neutral')"
+          (click)="onAction($event, 'neutral')"
+          (keydown.enter)="onAction($event, 'neutral')"
+          *ngIf="_buttons && _buttons.neutral"
+        >
+          {{ t(_buttons.neutral) }}
+        </button>
+        <button
+          class="submit"
+          type="submit"
+          [attr.data-thook]="'dialog-' + (_buttons?.positive || 'positive')"
+          (click)="onAction($event, 'positive')"
+          (keydown.enter)="onAction($event, 'positive')"
+          *ngIf="_buttons && _buttons.positive"
+        >
+          {{ t(_buttons.positive) }}
+        </button>
+      </footer>
+    </div>
+    <div class="nggv-backdrop"></div>
+  </div>
+</ng-container>

--- a/libs/angular/src/v-angular/modal/dialog/dialog.component.scss
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.component.scss
@@ -24,7 +24,9 @@
   --sg-z-index-modal: 1050;
   --text-primary-color: rgb(51, 51, 51);
 
-  @include mixins.dialog-modal-wrapper();
+  .modal-dialog__wrapper {
+    @include mixins.dialog-modal-wrapper();
+  }
 
   .modal-dialog__container {
     @include mixins.modal();

--- a/libs/angular/src/v-angular/modal/dialog/dialog.component.ts
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.component.ts
@@ -33,7 +33,7 @@ export class NggvDialogComponent implements OnInit {
   /** @internal */
   @HostBinding('class.gds-modal-dialog') baseClass = true
   /** @internal Defines the default visibility state of the dialog. */
-  @HostBinding('class.-active') _shown = false
+  private _shown = false
   @Input() set shown(value: boolean) {
     this._shown = value
     if (value) {


### PR DESCRIPTION
Added wrapping element with class `.modal-dialog__wrapper`, in which we include the wrapper mixin.