### PR TITLE
update README heading for chlorophyll lib

### DIFF
--- a/libs/chlorophyll/README.md
+++ b/libs/chlorophyll/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <img width="600" alt="chlorophyll" src="https://github.com/seb-oss/green/assets/11420341/8368cfdf-5335-42b3-9a7f-b03fd0d6433b">
-<h1>@sebgroup/green-core</h1>
+<h1>@sebgroup/chlorophyll</h1>
 <p>
 Chlorophyll a styling framework for Green Design System front-end components. It is primarily used to style the components in the React and Angular libraries, but also contains grid and utility classes.
 </p>


### PR DESCRIPTION
# PR Description: Update README Heading

## Changes Made
- Updated the `<h1>` heading in the README file:  
  - **Previous:** `<h1>@sebgroup/green-core</h1>`  
  - **Updated:** `<h1>@sebgroup/chlorophyll</h1>`

## Reason for the Change
- Reflect the updated project name to align with the current naming convention.

## Impact
- No functional impact; this change only updates the README documentation.
