### PR TITLE
Typeahead: Added emptyOptionLabel Typeahead input

### DIFF
--- a/libs/angular/src/v-angular/dropdown/dropdown.component.scss
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.scss
@@ -56,6 +56,12 @@
     &:hover {
       background: #e7e7e7;
     }
+
+    &:active {
+      background: inherit;
+      color: inherit;
+      border-color: inherit;
+    }
   }
 
   .gds-form-item__footer {

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
@@ -79,7 +79,7 @@ export class NggvTypeaheadInputComponent
    */
   @HostListener('document:keyup', ['$event'])
   onKeyUp(event: KeyboardEvent) {
-    if (event.code === 'Space') {
+    if (event.code === 'Space' && this.expanded) {
       event.preventDefault()
     }
   }

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
@@ -47,6 +47,9 @@ export class NggvTypeaheadInputComponent
   /** Used to determine the height of the inputin html */
   buttonHeight?: number
 
+  /** @internal Used to determine wether the input has been moved or not */
+  inputMoved = false
+
   constructor(
     private element: ElementRef,
     private renderer2: Renderer2,
@@ -98,6 +101,7 @@ export class NggvTypeaheadInputComponent
         // Get the height of the parent button so the input can be explicitly set to the same height since it's absolutely positioned
         this.buttonHeight =
           this.dropdownButton.getBoundingClientRect().height || 32 // Default to 2em;
+        this.inputMoved = true
       }
     }, 0)
   }
@@ -112,6 +116,10 @@ export class NggvTypeaheadInputComponent
       .pipe(takeUntil(this._destroy$))
       .subscribe((state) => {
         this.expanded = state
+
+        // Calling this function from onInit caused issues when DOM has not fully been initialized because of
+        // different CSS used to hide (but not remove) from DOM
+        if (!this.inputMoved) this.moveInput()
 
         if (this.expanded) {
           // Weird workaround for setting focus. Didn't set focus, but wrapping in setTimeout solved it.

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead.directive.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead.directive.ts
@@ -65,7 +65,7 @@ export class NggvTypeaheadDirective<
   @Input() unselectLabel?: string
 
   /** Custom label for the empty option */
-  @Input() emptyOptionLabel?: string;
+  @Input() emptyOptionLabel?: string
 
   /** Emits the entered string the user has written in the input */
   @Output() filterPhraseChange = new EventEmitter<string>()
@@ -111,7 +111,6 @@ export class NggvTypeaheadDirective<
 
   ngOnInit() {
     this.handleInputChanges()
-    this.inputValue$.next('')
 
     if (this.hostIsDropdown) this.createInput()
     else this.createDropdownList()
@@ -140,6 +139,9 @@ export class NggvTypeaheadDirective<
       .subscribe(([filteredValues, input]) =>
         this.setOptions(filteredValues, input),
       )
+
+    // Trigger the pipe when this function have been called
+    this.inputValue$.next('');
   }
 
   /**
@@ -185,8 +187,8 @@ export class NggvTypeaheadDirective<
       this.allowUnselect &&
       !input &&
       !(
-        Object.keys(filteredValues[0]).includes('key') &&
-        filteredValues[0].key == null
+        Object.keys(filteredValues[0] ?? {}).includes('key') &&
+        filteredValues[0]?.key == null
       )
     if (filteredValues.length === 0) {
       filteredValues = [this.emptyOption]

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead.directive.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead.directive.ts
@@ -64,6 +64,9 @@ export class NggvTypeaheadDirective<
   /** Custom label for the unselect option */
   @Input() unselectLabel?: string
 
+  /** Custom label for the empty option */
+  @Input() emptyOptionLabel?: string;
+
   /** Emits the entered string the user has written in the input */
   @Output() filterPhraseChange = new EventEmitter<string>()
 
@@ -83,7 +86,7 @@ export class NggvTypeaheadDirective<
   }
 
   get emptyOption(): OptionBase<any> {
-    return { key: null, label: 'label.nomatchingoptions', disabled: true }
+    return { key: null, label: this.emptyOptionLabel || 'label.nomatchingoptions', disabled: true }
   }
 
   /** Name of the component. nggv-dropdown if NggvDropdownComponent or nggv-input if NggvInputComponent */

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead.directive.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead.directive.ts
@@ -86,7 +86,11 @@ export class NggvTypeaheadDirective<
   }
 
   get emptyOption(): OptionBase<any> {
-    return { key: null, label: this.emptyOptionLabel || 'label.nomatchingoptions', disabled: true }
+    return {
+      key: null,
+      label: this.emptyOptionLabel || 'label.nomatchingoptions',
+      disabled: true,
+    }
   }
 
   /** Name of the component. nggv-dropdown if NggvDropdownComponent or nggv-input if NggvInputComponent */
@@ -141,7 +145,7 @@ export class NggvTypeaheadDirective<
       )
 
     // Trigger the pipe when this function have been called
-    this.inputValue$.next('');
+    this.inputValue$.next('')
   }
 
   /**


### PR DESCRIPTION
## Fix

- Added missing input for typeahead directive `emptyOptionLabel`.
- Update position for [hidden].
- Error converting null to object.