### PR TITLE
Typeahead: Prevent default only within component scope

### DIFF
--- a/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
@@ -669,7 +669,8 @@ const TypeaheadTemplate: StoryFn<StoryArgs> = (args: any) => {
           [unselectLabel]="unselectLabel"
           [nggvTypeahead]="searchFunction"
           [resultFormatter]="resultFormatter"
-          [selectedFormatter]="selectedFormatter">
+          [selectedFormatter]="selectedFormatter"
+          [emptyOptionLabel]="emptyOptionLabel">
 
           <ng-template #labelTpl>Custom Label</ng-template>
 

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
@@ -77,13 +77,9 @@ export class NggvTypeaheadInputComponent
    * Allow space to be inputted as text
    * @param event fired containing which key was released.
    */
-  @HostListener('document:keyup', ['$event', '$event.target'])
-  onKeyUp(event: KeyboardEvent, target: HTMLElement) {
-    if (
-      this.element.nativeElement.contains(target) &&
-      event.code === 'Space' &&
-      this.expanded
-    ) {
+  @HostListener('keyup', ['$event'])
+  onKeyUp(event: KeyboardEvent) {
+    if (event.code === 'Space' && this.expanded) {
       event.preventDefault()
     }
   }

--- a/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
+++ b/libs/angular/src/v-angular/dropdown/typeahead/typeahead-input/typeahead-input.component.ts
@@ -77,9 +77,13 @@ export class NggvTypeaheadInputComponent
    * Allow space to be inputted as text
    * @param event fired containing which key was released.
    */
-  @HostListener('document:keyup', ['$event'])
-  onKeyUp(event: KeyboardEvent) {
-    if (event.code === 'Space' && this.expanded) {
+  @HostListener('document:keyup', ['$event', '$event.target'])
+  onKeyUp(event: KeyboardEvent, target: HTMLElement) {
+    if (
+      this.element.nativeElement.contains(target) &&
+      event.code === 'Space' &&
+      this.expanded
+    ) {
       event.preventDefault()
     }
   }


### PR DESCRIPTION
Removed scope `document` to minimize listener to events emitting from within the component.