### PR TITLE
Dropdown: Size attribute applied to gds-form-control-header

### DIFF
--- a/.changeset/flat-cooks-look.md
+++ b/.changeset/flat-cooks-look.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+Dropdown: Added support for size small to header

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -332,6 +332,46 @@ describe('<gds-dropdown>', () => {
     await el.updateComplete
     await expect(el.displayValue).to.equal('Option 3 (updated)')
   })
+
+  it('should set gds-form-control-header class based on size', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown label="My dropdown" size="small">
+      </gds-dropdown>
+    `)
+    const gdsFormControlHeader = el.shadowRoot!.querySelector<HTMLElement>('[gds-element=gds-form-control-header]')!
+
+    await expect(gdsFormControlHeader.classList.contains('size-small')).to.be.true
+  })
+
+  it('should set gds-form-control-header class based on default size', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown label="My dropdown">
+      </gds-dropdown>
+    `)
+    const gdsFormControlHeader = el.shadowRoot!.querySelector<HTMLElement>('[gds-element=gds-form-control-header]')!
+
+    await expect(gdsFormControlHeader.classList.contains('size-medium')).to.be.true
+  })
+
+  it('should set gds-form-control-footer class based on size', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown label="My dropdown" size="small">
+      </gds-dropdown>
+    `)
+    const gdsFormControlFooter = el.shadowRoot!.querySelector<HTMLElement>('[gds-element=gds-form-control-footer]')!
+
+    await expect(gdsFormControlFooter.classList.contains('size-small')).to.be.true
+  })
+
+  it('should set gds-form-control-footer class based on default size', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown label="My dropdown">
+      </gds-dropdown>
+    `)
+    const gdsFormControlFooter = el.shadowRoot!.querySelector<HTMLElement>('[gds-element=gds-form-control-footer]')!
+
+    await expect(gdsFormControlFooter.classList.contains('size-medium')).to.be.true
+  })
 })
 
 describe('<gds-dropdown> interactions', () => {

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -236,7 +236,7 @@ export class GdsDropdown<ValueT = any>
       ${when(
         !this.hideLabel,
         () => html`
-          <gds-form-control-header>
+          <gds-form-control-header class="size-${this.size}">
             <label id="label" for="trigger" slot="label">${this.label}</label>
             ${when(
               this.supportingText.length > 0,


### PR DESCRIPTION
Added same logic that is already applied to gds-form-control-footer in Dropdown.

Also same that is found inside Datepicker component when applying size attribute to gds-form-control-header through a css class 

One discrepancy between datepicker and dropdown is that datepicker has size small/large and dropdown only small/medium but only small has specific css class inside gds-form-control-header so it seems to be OK.

Added tests for both gds-form-control-header and gds-form-control-footer cases