### PR TITLE
Add React 19 as peer dependency

### DIFF
--- a/.changeset/five-pillows-train.md
+++ b/.changeset/five-pillows-train.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': minor
+---
+
+**Dependencies:** Include React 19 in peer dependency constraint

--- a/.changeset/five-pillows-train.md
+++ b/.changeset/five-pillows-train.md
@@ -3,3 +3,7 @@
 ---
 
 **Dependencies:** Include React 19 in peer dependency constraint
+
+This update makes it possible to use @sebgroup/green-react with React 19 without complaints from NPM.
+
+Note, however, that the library is still not thoroughly tested with React 19, and all our unit tests still run against React 18. So proceed with caution.

--- a/libs/react/package.json
+++ b/libs/react/package.json
@@ -4,8 +4,8 @@
   "module": "./src/index.js",
   "version": "3.23.1",
   "peerDependencies": {
-    "react": "^17 || ^18",
-    "react-dom": "^17 || ^18"
+    "react": "^17 || ^18 || ^19",
+    "react-dom": "^17 || ^18 || ^19"
   },
   "dependencies": {
     "@sebgroup/green-core": "^1.63.1",


### PR DESCRIPTION
This update makes it possible to use `@sebgroup/green-react` with React 19 without complaints from NPM.

Note, however, that the library is still not thoroughly tested with React 19, and all our unit tests still run against React 18. So proceed with caution.