### PR TITLE
Checkbox & Radio hover styles

### DIFF
--- a/.changeset/fresh-paws-hug.md
+++ b/.changeset/fresh-paws-hug.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/chlorophyll': patch
+---
+
+**Chlorophyll:** Checkbox & Radio Button hover styles not to hint selected icon

--- a/libs/chlorophyll/scss/components/form/checkbox/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/checkbox/_mixins.scss
@@ -52,7 +52,7 @@ $invalid-color: var(--gds-sys-color-text-error);
   #{$selector}:hover
     #{$checkbox-selector}:not(.disabled, :disabled, :checked, :indeterminate)
     ~ i {
-    background-color: var(--gds-sys-color-base-100);
+    background-color: var(--gds-sys-color-base-200);
   }
 
   #{$selector} #{$checkbox-selector}:checked ~ i {

--- a/libs/chlorophyll/scss/components/form/checkbox/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/checkbox/_mixins.scss
@@ -1,9 +1,7 @@
-@use '../../../tokens/shame' as tokens;
 @use '../../../common';
-@use './tokens' as component-tokens;
 
-$valid-color: tokens.$intent-success-background;
-$invalid-color: tokens.$intent-danger-background;
+$valid-color: var(--gds-sys-color-dark-green-2);
+$invalid-color: var(--gds-sys-color-text-error);
 
 @mixin add-checkbox(
   $selector: 'label.form-control',
@@ -38,60 +36,35 @@ $invalid-color: tokens.$intent-danger-background;
     @include common.margin-end(4);
     margin-top: 0.0625rem;
     flex-shrink: 0;
-    box-shadow: inset 0 0 0 1px var(--gds-comp-checkbox-border-color);
+    box-shadow: inset 0 0 0 1px var(--gds-sys-color-text-primary);
     position: relative;
-    border-radius: var(--gds-comp-checkbox-border-radius);
-    background-color: var(--gds-comp-checkbox-container-color);
+    border-radius: var(--gds-sys-shape-corner-small);
+    background-color: transparent;
     flex: 0 0 auto;
-    height: var(--gds-comp-checkbox-container-width, 1rem);
-    width: var(--gds-comp-checkbox-container-width, 1rem);
-    transition:
-      color 0.3s ease-in-out,
-      all 0.3s ease-in-out;
-    &::after {
-      transition:
-        color 0.3s ease-in-out,
-        all 0.3s ease-in-out;
-    }
+    height: 1rem;
+    width: 1rem;
   }
 
   #{$selector} #{$checkbox-selector}:not(:checked):focus-visible ~ i {
-    box-shadow: inset 0 0 0 1px var(--gds-comp-checkbox-border-color-focus);
+    box-shadow: inset 0 0 0 1px var(--gds-sys-color-base-900);
   }
 
-  /* Hover state */
   #{$selector}:hover
     #{$checkbox-selector}:not(.disabled, :disabled, :checked, :indeterminate)
     ~ i {
-    border-color: var(--gds-comp-checkbox-hover-border-color);
-    box-shadow: inset 0 0 0 1px var(--gds-comp-checkbox-hover-border-color);
+    background-color: var(--gds-sys-color-base-100);
   }
 
-  #{$selector}:hover
-    #{$checkbox-selector}:not(:checked, :indeterminate, :disabled, .disabled)
-    ~ i::after {
-    border-color: var(--gds-comp-checkbox-hover-border-color);
-    opacity: 1;
-  }
-
-  // Checked state
   #{$selector} #{$checkbox-selector}:checked ~ i {
-    background-color: var(--gds-comp-checkbox-container-color-selected);
+    background-color: var(--gds-sys-color-base-900);
   }
 
-  #{$selector}:hover #{$checkbox-selector}:checked ~ i {
-    background-color: var(--gds-comp-checkbox-hover-border-color);
-    box-shadow: inset 0 0 0 1px var(--gds-comp-checkbox-hover-border-color);
-  }
-
-  /* Indeterminate state */
   #{$selector} #{$checkbox-selector}:indeterminate ~ i {
-    background-color: var(--gds-comp-checkbox-container-color-selected);
+    background-color: var(--gds-sys-color-base-900);
   }
 
   #{$selector} #{$checkbox-selector}:indeterminate ~ i::after {
-    border-bottom: 2px solid
-      var(--gds-comp-checkbox-border-color-selected, #fff);
+    border-bottom: 2px solid var(--gds-sys-color-background-primary);
     border-left: none;
     transform: scale(1) rotate(0deg);
     opacity: 1;
@@ -142,7 +115,6 @@ $invalid-color: tokens.$intent-danger-background;
     }
   }
 
-  /* Checkmark */
   #{$selector} #{$checkbox-selector} ~ i::after {
     content: '';
     opacity: 0;
@@ -150,9 +122,8 @@ $invalid-color: tokens.$intent-danger-background;
   }
 
   #{$selector} #{$checkbox-selector} ~ i::after {
-    border-bottom: 3px solid
-      var(--gds-comp-checkbox-border-color-selected, #fff);
-    border-left: 3px solid var(--gds-comp-checkbox-border-color-selected, #fff);
+    border-bottom: 3px solid var(--gds-sys-color-text-inverted);
+    border-left: 3px solid var(--gds-sys-color-text-inverted);
     height: 0.5rem;
     width: 1rem;
     left: 0;
@@ -161,7 +132,6 @@ $invalid-color: tokens.$intent-danger-background;
     transform-origin: center;
   }
 
-  /* Show the checkmark when checked */
   #{$selector} #{$checkbox-selector}:checked ~ i::after {
     opacity: 1;
   }

--- a/libs/chlorophyll/scss/components/form/radio/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/radio/_mixins.scss
@@ -50,7 +50,7 @@ $invalid-color: var(--gds-sys-color-text-error);
 
   /* Hover state */
   #{$selector}:hover #{$radio-selector}:not(.disabled, :disabled) ~ i {
-    background-color: var(--gds-sys-color-base-100);
+    background-color: var(--gds-sys-color-base-200);
   }
 
   /* Checked state */

--- a/libs/chlorophyll/scss/components/form/radio/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/radio/_mixins.scss
@@ -1,9 +1,7 @@
-@use '../../../tokens/shame' as tokens;
 @use '../../../common';
-@use './tokens' as component-tokens;
 
-$valid-color: tokens.$intent-success-background;
-$invalid-color: tokens.$intent-danger-background;
+$valid-color: var(--gds-sys-color-dark-green-2);
+$invalid-color: var(--gds-sys-color-text-error);
 
 @mixin add-radio(
   $selector: 'label.form-control',
@@ -33,48 +31,41 @@ $invalid-color: tokens.$intent-danger-background;
     margin-top: 0.0625rem;
     flex-shrink: 0;
     position: relative;
-    border-radius: var(--gds-comp-radio-border-radius);
+    border-radius: var(--gds-sys-shape-corner-round);
     display: flex;
-    height: var(--gds-comp-radio-container-height);
-    width: var(--gds-comp-radio-container-width);
+    height: 1rem;
+    width: 1rem;
     // Need to use box-shadow instead of border due to border causing fractional pixel offset on smaller pixel density screens
-    box-shadow: inset 0px 0px 0px 0.05rem var(--gds-comp-radio-border);
+    box-shadow: inset 0px 0px 0px 0.05rem var(--gds-sys-color-text-primary);
 
     &::after {
       content: '';
       width: 100%;
       height: 100%;
-      border-radius: var(--gds-comp-radio-border-radius);
-      background-color: var(--gds-comp-radio-dot);
+      border-radius: var(--gds-sys-shape-corner-round);
+      background-color: transparent;
       transform: scale(0.5);
     }
   }
 
   /* Hover state */
   #{$selector}:hover #{$radio-selector}:not(.disabled, :disabled) ~ i {
-    box-shadow: inset 0px 0px 0px 0.05rem var(--gds-comp-radio-border-hover);
-
-    &::after {
-      background-color: var(--gds-comp-radio-dot-hover);
-    }
+    background-color: var(--gds-sys-color-base-100);
   }
 
   /* Checked state */
   #{$selector} #{$radio-selector}:checked:not(.disabled, :disabled) ~ i {
-    box-shadow: inset 0px 0px 0px 0.05rem var(--gds-comp-radio-border-checked);
+    box-shadow: inset 0px 0px 0px 0.05rem var(--gds-sys-color-text-primary);
 
     &::after {
-      background-color: var(--gds-comp-radio-dot-checked);
+      background-color: var(--gds-sys-color-base);
     }
   }
 
   /* Checked Hover state */
   #{$selector}:hover #{$radio-selector}:checked:not(.disabled, :disabled) ~ i {
-    box-shadow: inset 0px 0px 0px 0.05rem
-      var(--gds-comp-radio-border-checked-hover);
-
     &::after {
-      background-color: var(--gds-comp-radio-dot-checked-hover);
+      background-color: var(--gds-sys-color-base-700);
     }
   }
 
@@ -99,8 +90,7 @@ $invalid-color: tokens.$intent-danger-background;
   #{$selector} #{$radio-selector}.disabled {
     ~ i {
       background-color: var(--gds-comp-radio-container-background-disabled);
-      box-shadow: inset 0px 0px 0px 0.05rem
-        var(--gds-comp-radio-border-disabled);
+      box-shadow: inset 0px 0px 0px 0.05rem var(--gds-sys-color-base-500);
     }
 
     ~ span {
@@ -110,7 +100,7 @@ $invalid-color: tokens.$intent-danger-background;
   #{$selector} #{$radio-selector}:disabled:checked,
   #{$selector} #{$radio-selector}:checked.disabled {
     ~ i::after {
-      background-color: var(--gds-comp-radio-dot-disabled);
+      background-color: var(--gds-sys-color-base-600);
     }
   }
 }
@@ -119,11 +109,11 @@ $invalid-color: tokens.$intent-danger-background;
   width: fit-content;
 
   .is-invalid & {
-    border: 1px solid tokens.$intent-danger-background;
+    border: 1px solid var(--gds-sys-color-text-error);
     border-radius: var(--gds-sys-shape-corner-medium);
   }
 
-  &.gds-radio-group-wrapper--horizontal {
+  &.radio-group-wrapper--horizontal {
     display: flex;
   }
 }

--- a/libs/chlorophyll/scss/tokens/_colors.scss
+++ b/libs/chlorophyll/scss/tokens/_colors.scss
@@ -1,7 +1,6 @@
 @mixin add-color-tokens() {
   --gds-ref-color-white: #ffffff;
   --gds-ref-color-black: #000000;
-
   --gds-ref-pallet-base000: hsl(0 0% 100%);
   --gds-ref-pallet-base100: hsl(0, 0%, 97%);
   --gds-ref-pallet-base200: hsl(0, 0%, 91%);
@@ -13,15 +12,51 @@
   --gds-ref-pallet-base800: hsl(0, 0%, 20%);
   --gds-ref-pallet-base900: hsl(0, 0%, 10%);
   --gds-ref-pallet-base1000: hsl(0 0% 0%);
-
   --gds-sys-color-blue: #41b0ee;
   --gds-sys-color-blue-dark-1: #0092e1;
   --gds-sys-color-blue-dark-2: #007ac7;
-
   --gds-sys-color-surface: var(--gds-ref-pallet-base000);
   --gds-sys-color-base: var(--gds-ref-pallet-base800);
   --gds-sys-color-font: var(--gds-ref-pallet-base800);
   --gds-sys-color-base-container: var(--gds-ref-pallet-base500);
-
   --gds-sys-color-focus-outline: var(--gds-ref-pallet-base1000);
+
+  --gds-sys-color-blue: #41b0ee;
+  --gds-sys-color-dark-blue-1: #41b0ee;
+  --gds-sys-color-dark-blue-2: #007ac7;
+  --gds-sys-color-green: #60cd18;
+  --gds-sys-color-dark-green-1: #45b400;
+  --gds-sys-color-dark-green-2: #308800;
+  --gds-sys-color-yellow: #ffc500;
+  --gds-sys-color-dark-yellow-1: #ffb400;
+  --gds-sys-color-dark-yellow-2: #f8a000;
+  --gds-sys-color-text-primary: #333333;
+  --gds-sys-color-text-secondary: #ababab;
+  --gds-sys-color-text-white: #ffffff;
+  --gds-sys-color-text-black: #333333;
+  --gds-sys-color-text-inverted: #ffffff;
+  --gds-sys-color-text-link: #0062bc;
+  --gds-sys-color-text-error: #9f000a;
+  --gds-sys-color-text-disabled: #adadad;
+  --gds-sys-color-red: #f03529;
+  --gds-sys-color-dark-red-1: #d81a1a;
+  --gds-sys-color-dark-red-2: #bb000c;
+  --gds-sys-color-purple: #673ab6;
+  --gds-sys-color-dark-purple-1: #4f2c99;
+  --gds-sys-color-dark-purple-2: #3f2587;
+  --gds-sys-color-white: #ffffff;
+  --gds-sys-color-black: #000000;
+  --gds-sys-color-background-primary: #ffffff;
+  --gds-sys-color-background-secondary: #eeeeee;
+  --gds-sys-color-base-100: #f8f8f8;
+  --gds-sys-color-base-200: #e9e9e9;
+  --gds-sys-color-base-300: #dedede;
+  --gds-sys-color-base-400: #cecece;
+  --gds-sys-color-base-500: #adadad;
+  --gds-sys-color-base-600: #868686;
+  --gds-sys-color-base-700: #494949;
+  --gds-sys-color-base-800: #333333;
+  --gds-sys-color-base-900: #1a1a1a;
+  --gds-sys-color-hover-10: rgba(255, 255, 255, 0.1);
+  --gds-sys-color-hover-20: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
This PR alters the current 2016 checkbox & radio hover styles and adds our 2016 color tokens.

There's an issue on mobile where the hover styles make it look like multiple items are selected. 

We need to update Figma aswell.