### PR TITLE
NggCoreRenderer animations support

### DIFF
--- a/.changeset/stupid-turtles-cheer.md
+++ b/.changeset/stupid-turtles-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': minor
+---
+
+**NggCoreRenderer:** Add provider for supporting animations when using NggCoreRenderer

--- a/.changeset/stupid-turtles-cheer.md
+++ b/.changeset/stupid-turtles-cheer.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-angular': minor
 ---
 
-**NggCoreRenderer:** Add provider for supporting animations when using NggCoreRenderer
+**NggCoreRenderer:** Add provider for supporting animations when using `NggCoreRenderer`. Fixes #1997

--- a/apps/angular-lib-dev/src/app/app.module.ts
+++ b/apps/angular-lib-dev/src/app/app.module.ts
@@ -1,13 +1,15 @@
 import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
+import { provideCoreRendererWithAnimations } from '@sebgroup/green-angular/src/lib/shared'
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  imports: [BrowserAnimationsModule, BrowserModule, AppRoutingModule],
+  providers: [provideCoreRendererWithAnimations()],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/angular-lib-dev/src/app/form/form.module.ts
+++ b/apps/angular-lib-dev/src/app/form/form.module.ts
@@ -1,15 +1,8 @@
 import { CommonModule } from '@angular/common'
-import {
-  CUSTOM_ELEMENTS_SCHEMA,
-  NgModule,
-  RendererFactory2,
-} from '@angular/core'
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 
-import {
-  NggCoreFormsModule,
-  NggCoreRendererFactory,
-} from '@sebgroup/green-angular/src/lib/shared'
+import { NggCoreFormsModule } from '@sebgroup/green-angular/src/lib/shared'
 import { FormRoutingModule } from './form-routing.module'
 import { FormComponent } from './form.component'
 
@@ -24,13 +17,5 @@ import { FormComponent } from './form.component'
   ],
   exports: [],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  providers: [
-    {
-      // By providing our custom renderer factory, we can use <gds-*> elements without any extra directives.
-      // The NggCoreRenderer will handle element name scoping automatically.
-      provide: RendererFactory2,
-      useClass: NggCoreRendererFactory,
-    },
-  ],
 })
 export class FormModule {}

--- a/libs/angular/src/lib/shared/core-renderer/core-renderer.spec.ts
+++ b/libs/angular/src/lib/shared/core-renderer/core-renderer.spec.ts
@@ -1,7 +1,11 @@
 import { Component, RendererFactory2 } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 
-import { NggCoreRendererFactory } from './core-renderer'
+import {
+  NggCoreRendererFactory,
+  provideCoreRenderer,
+  provideCoreRendererWithAnimations,
+} from './core-renderer'
 
 @Component({
   template: '<gds-button></gds-button>',
@@ -19,12 +23,26 @@ describe('NggCoreRenderer', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      providers: [
-        {
-          provide: RendererFactory2,
-          useClass: NggCoreRendererFactory,
-        },
-      ],
+      providers: [provideCoreRenderer()],
+    })
+    const fixture = TestBed.createComponent(TestComponent)
+    parent = fixture.debugElement.nativeElement
+    fixture.detectChanges()
+  })
+
+  it('should create an element with the scoped tag name', () => {
+    expect(parent.querySelector('gds-button-scoped')).toBeTruthy()
+  })
+})
+
+describe('NggCoreRenderer (with animations)', () => {
+  let component: TestComponent
+  let parent: HTMLElement
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      providers: [provideCoreRendererWithAnimations()],
     })
     const fixture = TestBed.createComponent(TestComponent)
     parent = fixture.debugElement.nativeElement

--- a/libs/angular/src/lib/shared/core-renderer/core-renderer.spec.ts
+++ b/libs/angular/src/lib/shared/core-renderer/core-renderer.spec.ts
@@ -1,5 +1,6 @@
-import { Component, RendererFactory2 } from '@angular/core'
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
 import {
   NggCoreRendererFactory,
@@ -23,6 +24,7 @@ describe('NggCoreRenderer', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [provideCoreRenderer()],
     })
     const fixture = TestBed.createComponent(TestComponent)
@@ -41,7 +43,9 @@ describe('NggCoreRenderer (with animations)', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule],
       declarations: [TestComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [provideCoreRendererWithAnimations()],
     })
     const fixture = TestBed.createComponent(TestComponent)

--- a/libs/angular/src/lib/shared/core-renderer/core-renderer.ts
+++ b/libs/angular/src/lib/shared/core-renderer/core-renderer.ts
@@ -128,6 +128,9 @@ export class NggCoreRendererFactory implements RendererFactory2 {
   }
 }
 
+/**
+ * Returns a AnimationRendererFactory configured to use the NggCoreRendererFactory as a delegate.
+ */
 export function animationsCoreRendererFactory(
   delegate: DomRendererFactory2,
   engine: AnimationEngine,
@@ -140,6 +143,15 @@ export function animationsCoreRendererFactory(
 /**
  * Provide the NggCoreRendererFactory to use <gds-*> elements without any extra directives.
  * The NggCoreRenderer will handle element name scoping automatically.
+ *
+ * Example:
+ * ```ts
+ * @NgModule({
+ *  providers: [provideCoreRenderer()],
+ *  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+ * })
+ * export class AppModule {}
+ * ```
  */
 export const provideCoreRenderer = () => ({
   provide: RendererFactory2,
@@ -151,6 +163,17 @@ export const provideCoreRenderer = () => ({
  * The NggCoreRenderer will handle element name scoping automatically.
  *
  * This factory also provides the Angular animations renderer.
+ *
+ *
+ * Example:
+ * ```ts
+ * @NgModule({
+ *  imports: [BrowserAnimationsModule],
+ *  providers: [provideCoreRendererWithAnimations()],
+ *  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+ * })
+ * export class AppModule {}
+ * ```
  */
 export const provideCoreRendererWithAnimations = () => ({
   provide: RendererFactory2,

--- a/libs/angular/src/lib/shared/core-renderer/core-renderer.ts
+++ b/libs/angular/src/lib/shared/core-renderer/core-renderer.ts
@@ -1,5 +1,10 @@
 import {
+  ɵAnimationEngine as AnimationEngine,
+  ɵAnimationRendererFactory as AnimationRendererFactory,
+} from '@angular/animations/browser'
+import {
   Injectable,
+  NgZone,
   Renderer2,
   RendererFactory2,
   RendererStyleFlags2,
@@ -122,3 +127,33 @@ export class NggCoreRendererFactory implements RendererFactory2 {
     return new NggCoreRenderer(renderer)
   }
 }
+
+export function animationsCoreRendererFactory(
+  delegate: DomRendererFactory2,
+  engine: AnimationEngine,
+  zone: NgZone,
+) {
+  const crf = new NggCoreRendererFactory(delegate)
+  return new AnimationRendererFactory(crf, engine, zone)
+}
+
+/**
+ * Provide the NggCoreRendererFactory to use <gds-*> elements without any extra directives.
+ * The NggCoreRenderer will handle element name scoping automatically.
+ */
+export const provideCoreRenderer = () => ({
+  provide: RendererFactory2,
+  useClass: NggCoreRendererFactory,
+})
+
+/**
+ * Provide the NggCoreRendererFactory to use <gds-*> elements without any extra directives.
+ * The NggCoreRenderer will handle element name scoping automatically.
+ *
+ * This factory also provides the Angular animations renderer.
+ */
+export const provideCoreRendererWithAnimations = () => ({
+  provide: RendererFactory2,
+  useFactory: animationsCoreRendererFactory,
+  deps: [DomRendererFactory2, AnimationEngine, NgZone],
+})

--- a/libs/core/src/storybook-docs/guides/installing.mdx
+++ b/libs/core/src/storybook-docs/guides/installing.mdx
@@ -100,17 +100,12 @@ If you are using a lot of web components, it can feel a bit cluttered with all t
 In your module:
 
 ```ts
-import { CUSTOM_ELEMENTS_SCHEMA, RendererFactory2 } from '@angular/core'
-import { NggCoreRendererFactory } from '@sebgroup/green-angular/src/lib/shared'
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
+import { provideCoreRenderer } from '@sebgroup/green-angular/src/lib/shared'
 
 @NgModule({
-    // Provide the NggCoreRenderer as a custom renderer
-    providers: [
-      {
-        provide: RendererFactory2,
-        useClass: NggCoreRendererFactory,
-      },
-    ],
+    // Provides `NggCoreRenderer` as a custom renderer
+    providers: [provideCoreRenderer()],
     // CUSTOM_ELEMENTS_SCHEMA is still needed
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
@@ -121,10 +116,7 @@ Or, if you are only using standalone components, you can either create a root ap
 ```ts
 // app.config.ts
 const appConfig: ApplicationConfig = {
-  providers: [...other providers..., {
-    provide: RendererFactory2,
-    useClass: NggCoreRendererFactory,
-  }]
+  providers: [...other providers..., provideCoreRenderer()]
 };
 
 // main.ts
@@ -136,6 +128,24 @@ Now you can use Green Core components in your template without any special direc
 
 ```html
 <gds-button>Click me!</gds-button>
+```
+
+#### Using the custom renderer with Angular animations
+
+If you also need to use Angular animations, you need to use a special version of the provider. This is because Angular animations also use a custom renderer. So we need a bit of specialized initialization to make sure both the Green Core renderer and the Angular animations renderer can coexist.
+
+All you need to do on your end is to use `provideCoreRendererWithAnimations()` instead of `provideCoreRenderer()`.
+
+```ts
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { provideCoreRendererWithAnimations } from '@sebgroup/green-angular/src/lib/shared'
+
+@NgModule({
+    imports: [BrowserAnimationsModule] // You also need to make sure you have imported the `BrowserAnimationsModule` module
+    providers: [provideCoreRendererWithAnimations()],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
 ```
 
 ### Using React


### PR DESCRIPTION
This PR adds a provider for supporting animations when using `NggCoreRenderer`

Before:
```ts
@NgModule({
  declarations: [AppComponent],
  imports: [BrowserAnimationsModule, BrowserModule, AppRoutingModule],
  providers: [{
    provide: RendererFactory2,
    useClass: NggCoreRendererFactory,
  }],
  bootstrap: [AppComponent],
})
export class AppModule {}
```

Now:
```ts
@NgModule({
  declarations: [AppComponent],
  imports: [BrowserAnimationsModule, BrowserModule, AppRoutingModule],
  providers: [provideCoreRendererWithAnimations()],
  bootstrap: [AppComponent],
})
export class AppModule {}
```

Or, if you don't need animations:
```ts
@NgModule({
  declarations: [AppComponent],
  imports: [BrowserModule, AppRoutingModule],
  providers: [provideCoreRenderer()],
  bootstrap: [AppComponent],
})
export class AppModule {}
```

The old way will also still work as before, so this is not a breaking change.

Related to #1997