### PR TITLE
Popover: Change default position strategy to shift rather than flip

### DIFF
--- a/.changeset/gentle-clocks-happen.md
+++ b/.changeset/gentle-clocks-happen.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Popover:** Change default positioning middleware to shift position rather than flip in order to use more available viewport space.

--- a/libs/core/src/components/datepicker/datepicker.ts
+++ b/libs/core/src/components/datepicker/datepicker.ts
@@ -324,110 +324,112 @@ class Datepicker extends GdsFormControlElement<Date> {
           this._elCalendar.then((cal) => cal.focus())
         }}
       >
-        <gds-flex
-          align-items="center"
-          justify-content="space-between"
-          gap="s"
-          padding="m m 0 m"
-        >
-          <gds-button
-            @click=${this.#handleDecrementFocusedMonth}
-            aria-label=${msg('Previous month')}
-            rank="tertiary"
-            size="small"
+        <gds-div overflow="auto">
+          <gds-flex
+            align-items="center"
+            justify-content="space-between"
+            gap="s"
+            padding="m m 0 m"
           >
-            <gds-icon-chevron-left></gds-icon-chevron-left>
-          </gds-button>
-          <gds-dropdown
-            .value=${this._focusedMonth.toString()}
-            @change=${this.#handleMonthChange}
-            .maxHeight=${300}
-            label="${msg('Month')}"
-            size="small"
-            class="month"
-            hide-label
-          >
-            <gds-option value="0">${msg('January')}</gds-option>
-            <gds-option value="1">${msg('February')}</gds-option>
-            <gds-option value="2">${msg('March')}</gds-option>
-            <gds-option value="3">${msg('April')}</gds-option>
-            <gds-option value="4">${msg('May')}</gds-option>
-            <gds-option value="5">${msg('June')}</gds-option>
-            <gds-option value="6">${msg('July')}</gds-option>
-            <gds-option value="7">${msg('August')}</gds-option>
-            <gds-option value="8">${msg('September')}</gds-option>
-            <gds-option value="9">${msg('October')}</gds-option>
-            <gds-option value="10">${msg('November')}</gds-option>
-            <gds-option value="11">${msg('December')}</gds-option>
-          </gds-dropdown>
-          <gds-dropdown
-            .value=${this._focusedYear.toString()}
-            @change=${this.#handleYearChange}
-            .maxHeight=${300}
-            label="${msg('Year')}"
-            size="small"
-            class="year"
-            hide-label
-          >
-            ${repeat(
-              this.#years,
-              (year) => year,
-              (year) => html`<gds-option value=${year}>${year}</gds-option>`,
-            )}
-          </gds-dropdown>
-          <gds-button
-            @click=${this.#handleIncrementFocusedMonth}
-            aria-label=${msg('Next month')}
-            rank="tertiary"
-            size="small"
-          >
-            <gds-icon-chevron-right></gds-icon-chevron-right>
-          </gds-button>
-        </gds-flex>
+            <gds-button
+              @click=${this.#handleDecrementFocusedMonth}
+              aria-label=${msg('Previous month')}
+              rank="tertiary"
+              size="small"
+            >
+              <gds-icon-chevron-left></gds-icon-chevron-left>
+            </gds-button>
+            <gds-dropdown
+              .value=${this._focusedMonth.toString()}
+              @change=${this.#handleMonthChange}
+              .maxHeight=${300}
+              label="${msg('Month')}"
+              size="small"
+              class="month"
+              hide-label
+            >
+              <gds-option value="0">${msg('January')}</gds-option>
+              <gds-option value="1">${msg('February')}</gds-option>
+              <gds-option value="2">${msg('March')}</gds-option>
+              <gds-option value="3">${msg('April')}</gds-option>
+              <gds-option value="4">${msg('May')}</gds-option>
+              <gds-option value="5">${msg('June')}</gds-option>
+              <gds-option value="6">${msg('July')}</gds-option>
+              <gds-option value="7">${msg('August')}</gds-option>
+              <gds-option value="8">${msg('September')}</gds-option>
+              <gds-option value="9">${msg('October')}</gds-option>
+              <gds-option value="10">${msg('November')}</gds-option>
+              <gds-option value="11">${msg('December')}</gds-option>
+            </gds-dropdown>
+            <gds-dropdown
+              .value=${this._focusedYear.toString()}
+              @change=${this.#handleYearChange}
+              .maxHeight=${300}
+              label="${msg('Year')}"
+              size="small"
+              class="year"
+              hide-label
+            >
+              ${repeat(
+                this.#years,
+                (year) => year,
+                (year) => html`<gds-option value=${year}>${year}</gds-option>`,
+              )}
+            </gds-dropdown>
+            <gds-button
+              @click=${this.#handleIncrementFocusedMonth}
+              aria-label=${msg('Next month')}
+              rank="tertiary"
+              size="small"
+            >
+              <gds-icon-chevron-right></gds-icon-chevron-right>
+            </gds-button>
+          </gds-flex>
 
-        <gds-calendar
-          id="calendar"
-          @change=${this.#handleCalendarChange}
-          @gds-date-focused=${this.#handleCalendarFocusChange}
-          .focusedMonth=${this._focusedMonth}
-          .focusedYear=${this._focusedYear}
-          .value=${this.value}
-          .min=${this.min}
-          .max=${this.max}
-          .showWeekNumbers=${this.showWeekNumbers}
-          .disabledWeekends=${this.disabledWeekends}
-          .disabledDates=${this.disabledDates}
-        ></gds-calendar>
+          <gds-calendar
+            id="calendar"
+            @change=${this.#handleCalendarChange}
+            @gds-date-focused=${this.#handleCalendarFocusChange}
+            .focusedMonth=${this._focusedMonth}
+            .focusedYear=${this._focusedYear}
+            .value=${this.value}
+            .min=${this.min}
+            .max=${this.max}
+            .showWeekNumbers=${this.showWeekNumbers}
+            .disabledWeekends=${this.disabledWeekends}
+            .disabledDates=${this.disabledDates}
+          ></gds-calendar>
 
-        <gds-flex
-          align-items="center"
-          justify-content="space-between"
-          padding="0 m m m"
-        >
-          <gds-button
-            rank="tertiary"
-            size="small"
-            @click=${(e: MouseEvent) => {
-              e.stopPropagation()
-              this.value = undefined
-              this.open = false
-              this.#dispatchChangeEvent()
-            }}
+          <gds-flex
+            align-items="center"
+            justify-content="space-between"
+            padding="0 m m m"
           >
-            ${msg('Clear')}
-          </gds-button>
-          ${until(this.#renderBackToValidRangeButton(), nothing)}
-          <gds-button
-            rank="tertiary"
-            size="small"
-            @click=${(e: MouseEvent) => {
-              e.stopPropagation()
-              this.#focusDate(new Date())
-            }}
-          >
-            ${msg('Today')}
-          </gds-button>
-        </gds-flex>
+            <gds-button
+              rank="tertiary"
+              size="small"
+              @click=${(e: MouseEvent) => {
+                e.stopPropagation()
+                this.value = undefined
+                this.open = false
+                this.#dispatchChangeEvent()
+              }}
+            >
+              ${msg('Clear')}
+            </gds-button>
+            ${until(this.#renderBackToValidRangeButton(), nothing)}
+            <gds-button
+              rank="tertiary"
+              size="small"
+              @click=${(e: MouseEvent) => {
+                e.stopPropagation()
+                this.#focusDate(new Date())
+              }}
+            >
+              ${msg('Today')}
+            </gds-button>
+          </gds-flex>
+        </gds-div>
       </gds-popover>
     `
   }

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -458,14 +458,7 @@ export class GdsDropdown<ValueT = any>
   }
 
   #calcMaxHeight = (trigger: HTMLElement) => {
-    const triggerRect = trigger.getBoundingClientRect()
-    const windowHeight = window.innerHeight
-    const bottomSpace = windowHeight - triggerRect.bottom
-    const topSpace = triggerRect.top
-
-    let height = Math.min(topSpace, this.maxHeight)
-    if (bottomSpace > topSpace) height = Math.min(bottomSpace, this.maxHeight)
-
+    const height = Math.min(window.innerHeight, this.maxHeight)
     return `${height - 16}px`
   }
 

--- a/libs/core/src/components/popover/popover.ts
+++ b/libs/core/src/components/popover/popover.ts
@@ -5,10 +5,10 @@ import { classMap } from 'lit/directives/class-map.js'
 import {
   autoUpdate,
   computePosition,
-  flip,
   Middleware,
   offset,
   Placement,
+  shift,
 } from '@floating-ui/dom'
 
 import { GdsElement } from '../../gds-element'
@@ -119,7 +119,7 @@ export class GdsPopover extends GdsElement {
    * By default, the popover maxHeight will be set to a hard coded pixel value (check source code).
    */
   @property({ attribute: false })
-  calcMaxHeight = (_referenceEl: HTMLElement) => `500px`
+  calcMaxHeight = (_referenceEl: HTMLElement) => `${window.innerHeight - 16}px`
 
   /**
    * Whether the popover is nonmodal. When true, the popover will not trap focus and other elements
@@ -156,7 +156,13 @@ export class GdsPopover extends GdsElement {
    * Defaults to `[offset(8), flip()]`
    */
   @property({ attribute: false })
-  floatingUIMiddleware: Middleware[] = [offset(8), flip()]
+  floatingUIMiddleware: Middleware[] = [
+    offset(8),
+    shift({
+      crossAxis: true,
+      padding: 8,
+    }),
+  ]
 
   @state()
   private _trigger: HTMLElement | undefined = undefined


### PR DESCRIPTION
This PR changes the default behavior of popovers to shift instead of flip when there is limited space. This will cause the popover to render on top of the trigger element, but it will use space more optimally.

Here is an example of the old behavior. There is limited space below and above, the popover flips and resizes to fit above the trigger, and thus leaves very little space for the listbox:
![image](https://github.com/user-attachments/assets/e083452b-d732-4abf-af63-1515b9a11d1e)

And here is how it behaves now. Instead of flipping and resizing, the popover shifts, covering the trigger but allowing more space for the listbox, which arguably is the most important element for the user:
<img width="764" alt="Screenshot 2025-03-10 at 17 06 45" src="https://github.com/user-attachments/assets/baa03577-2ad0-4dee-a86a-27e16f0c9d1f" />
