### PR TITLE
fix: ensure dropdown-list is rendered above other inputs

### DIFF
--- a/.changeset/moody-zoos-warn.md
+++ b/.changeset/moody-zoos-warn.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+Fix for dropdown layering.

--- a/.changeset/moody-zoos-warn.md
+++ b/.changeset/moody-zoos-warn.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-angular': patch
 ---
 
-Fix for dropdown layering.
+Fix for dropdown layering to render list above other inputs.

--- a/libs/angular/src/v-angular/dropdown/dropdown.component.scss
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.scss
@@ -39,6 +39,7 @@
   }
 
   @include form-group.add-form-item();
+  position: initial; // counteracts position: relative in mixin
 
   .gds-field-label--optional {
     font-weight: 400;

--- a/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
@@ -572,6 +572,26 @@ const ComboTemplate: StoryFn<StoryArgs> = (args: any) => {
           style="margin-left: 0.25rem;"
           [formControl]="formControl">
         </nggv-input>
+      </div>
+      <div>
+        <nggv-dropdown
+          label="Dropdown 2"
+          [placeholder]="placeholder"
+          [options]="options"
+          [required]="true"
+          [invalid]="true"
+          error="This is a permanent error"
+          [formControl]="formControl">
+        </nggv-dropdown>
+      </div>
+      <div>
+        <nggv-input
+          label="Input 2"
+          [placeholder]="placeholder"
+          [required]="true"
+          style="margin-left: 0.25rem;"
+          [formControl]="formControl">
+        </nggv-input>
       </div>`,
     props: {
       ...args,


### PR DESCRIPTION
## Fix

Fix for where the dropdown list was rendered "below" other inputs:

![image](https://github.com/user-attachments/assets/64b95760-86a1-4166-8e57-039829f1121b)

Added example to existing story `ComboTemplate` for testing changes.