### PR TITLE
Dropdown: Fix `aria-hidden` issues and combobox positioning

### DIFF
--- a/.changeset/bright-ducks-end.md
+++ b/.changeset/bright-ducks-end.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Dropdown:** Fix issue with elements being `aria-hidden` while also having focus

--- a/.changeset/gentle-cheetahs-impress.md
+++ b/.changeset/gentle-cheetahs-impress.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Dropdown:** Fix popover overlap when using `combobox` option

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -621,7 +621,7 @@ describe('<gds-dropdown searchable>', () => {
     await el.updateComplete
 
     const options = el.querySelectorAll(
-      `${getScopedTagName('gds-option')}:not([aria-hidden="true"])`,
+      `${getScopedTagName('gds-option')}:not([inert])`,
     )
 
     await expect(options.length).to.equal(1)
@@ -650,7 +650,7 @@ describe('<gds-dropdown searchable>', () => {
     await el.updateComplete
 
     const options = el.querySelectorAll(
-      `${getScopedTagName('gds-option')}:not([aria-hidden="true"])`,
+      `${getScopedTagName('gds-option')}:not([inert])`,
     )
 
     await expect(options.length).to.equal(1)
@@ -855,7 +855,7 @@ describe('<gds-dropdown combobox>', () => {
     comboInputEl!.dispatchEvent(new Event('input'))
 
     const options = el.querySelectorAll(
-      `${getScopedTagName('gds-option')}:not([aria-hidden="true"])`,
+      `${getScopedTagName('gds-option')}:not([inert])`,
     )
 
     await expect(options.length).to.equal(1)
@@ -887,7 +887,7 @@ describe('<gds-dropdown combobox>', () => {
     await aTimeout(0)
 
     const options = el.querySelectorAll(
-      `${getScopedTagName('gds-option')}:not([aria-hidden="true"])`,
+      `${getScopedTagName('gds-option')}:not([inert])`,
     )
 
     await expect(options.length).to.equal(1)

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -3,12 +3,14 @@ import { property, query, queryAsync } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 import { unsafeHTML } from 'lit/directives/unsafe-html.js'
 import { when } from 'lit/directives/when.js'
+import { flip, offset } from '@floating-ui/dom'
 
 import { gdsCustomElement, html } from '../../scoping'
 import { tokens } from '../../tokens.style'
 import { observeLightDOM } from '../../utils/decorators/observe-light-dom'
 import { watch } from '../../utils/decorators/watch'
 import { GdsFormControlElement } from '../form/form-control'
+import { GdsPopover, UIStateChangeReason } from '../popover'
 import styles from './dropdown.styles'
 
 import type { GdsListbox } from '../../primitives/listbox'
@@ -25,8 +27,6 @@ import '../icon/icons/checkmark'
 import '../icon/icons/chevron-bottom'
 import '../popover'
 import '../button'
-
-import { UIStateChangeReason } from '../popover'
 
 /**
  * @element gds-dropdown
@@ -277,6 +277,9 @@ export class GdsDropdown<ValueT = any>
         .calcMaxHeight=${this.#calcMaxHeight}
         .disableMobileStyles=${this.disableMobileStyles || this.combobox}
         .nonmodal=${this.combobox}
+        .floatingUIMiddleware=${this.combobox
+          ? [offset(8), flip()]
+          : GdsPopover.DefaultMiddleware}
         @gds-ui-state=${this.#handlePopoverStateChange}
       >
         <gds-field-base
@@ -459,6 +462,17 @@ export class GdsDropdown<ValueT = any>
   }
 
   #calcMaxHeight = (trigger: HTMLElement) => {
+    if (this.combobox) {
+      const triggerRect = trigger.getBoundingClientRect()
+      const windowHeight = window.innerHeight
+      const bottomSpace = windowHeight - triggerRect.bottom
+      const topSpace = triggerRect.top
+
+      let height = Math.min(topSpace, this.maxHeight)
+      if (bottomSpace > topSpace) height = Math.min(bottomSpace, this.maxHeight)
+      return `${height - 16}px`
+    }
+
     const height = Math.min(window.innerHeight, this.maxHeight)
     return `${height - 16}px`
   }

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -240,6 +240,7 @@ export class GdsDropdown<ValueT = any>
     this.updateComplete.then(() => {
       this._handleLightDOMChange()
       this._handleValueChange()
+      this._handleOpenChange()
     })
   }
 
@@ -586,7 +587,7 @@ export class GdsDropdown<ValueT = any>
    * Emits `gds-ui-state`event and does some other house-keeping when the open state changes.
    */
   @watch('open')
-  private _onOpenChange() {
+  private _handleOpenChange() {
     const open = this.open
 
     this.#optionElements?.forEach((o) => (o.hidden = !open))

--- a/libs/core/src/components/popover/popover.ts
+++ b/libs/core/src/components/popover/popover.ts
@@ -268,7 +268,7 @@ export class GdsPopover extends GdsElement {
             'use-modal-in-mobile': !this.disableMobileStyles,
             'has-backdrop': Boolean(this.backdrop && this.backdrop === 'true'),
           })}"
-          aria-hidden="${String(!this.open)}"
+          ?inert="${!this.open}"
           @close=${() => this.open && this.#handleCancel()}
         >
           <header>

--- a/libs/core/src/components/popover/popover.ts
+++ b/libs/core/src/components/popover/popover.ts
@@ -44,6 +44,17 @@ export class GdsPopover extends GdsElement {
   static styles = unsafeCSS(styles)
 
   /**
+   * The default set of middleware for Floating UI positioning used by GdsPopover.
+   */
+  static DefaultMiddleware: Middleware[] = [
+    offset(8),
+    shift({
+      crossAxis: true,
+      padding: 8,
+    }),
+  ]
+
+  /**
    * Whether the popover is open.
    */
   @property({ type: Boolean, reflect: true })
@@ -156,13 +167,7 @@ export class GdsPopover extends GdsElement {
    * Defaults to `[offset(8), flip()]`
    */
   @property({ attribute: false })
-  floatingUIMiddleware: Middleware[] = [
-    offset(8),
-    shift({
-      crossAxis: true,
-      padding: 8,
-    }),
-  ]
+  floatingUIMiddleware: Middleware[] = GdsPopover.DefaultMiddleware
 
   @state()
   private _trigger: HTMLElement | undefined = undefined

--- a/libs/core/src/primitives/listbox/option.styles.ts
+++ b/libs/core/src/primitives/listbox/option.styles.ts
@@ -55,7 +55,7 @@ const style = css`
       }
     }
 
-    :host([aria-hidden='true']) {
+    :host([inert]) {
       display: none;
     }
 

--- a/libs/core/src/primitives/listbox/option.trans.styles.scss
+++ b/libs/core/src/primitives/listbox/option.trans.styles.scss
@@ -25,7 +25,7 @@
     outline-offset: -0.25rem;
   }
 
-  :host([aria-hidden='true']) {
+  :host([inert]) {
     display: none;
   }
 

--- a/libs/core/src/primitives/listbox/option.ts
+++ b/libs/core/src/primitives/listbox/option.ts
@@ -45,17 +45,18 @@ export class GdsOption extends Focusable(GdsElement) {
    * Controls whether the option is visible or not.
    */
   @property({
-    attribute: 'aria-hidden',
+    type: Boolean,
     reflect: true,
   })
   get hidden(): boolean {
     return this.#hidden
   }
   set hidden(value: string | boolean) {
-    if (this.isPlaceholder) return
-
-    this.#hidden = value === 'true' || value === true
-    this.setAttribute('aria-hidden', value.toString())
+    const strValue = value.toString()
+    this.#hidden = strValue === 'true'
+    this.#hidden
+      ? this.setAttribute('inert', '')
+      : this.removeAttribute('inert')
   }
   #hidden = false
 
@@ -93,28 +94,24 @@ export class GdsOption extends Focusable(GdsElement) {
     super.connectedCallback()
     this.setAttribute('role', 'option')
 
-    if (this.isPlaceholder) {
-      this.#hidden = true
-      this.setAttribute('aria-hidden', 'true')
-    }
-
-    this.updateComplete.then(() =>
-      TransitionalStyles.instance.apply(this, 'gds-option'),
-    )
+    this.updateComplete.then(() => {
+      if (this.isPlaceholder) {
+        this.hidden = true
+      }
+      TransitionalStyles.instance.apply(this, 'gds-option')
+    })
   }
 
   get parentElement() {
     return super.parentElement as OptionsContainer
   }
 
-  @watch('isplaceholder')
+  @watch('isPlaceholder')
   private _handlePlaceholderStatusChange() {
     if (this.isPlaceholder) {
-      this.#hidden = true
-      this.setAttribute('aria-hidden', 'true')
+      this.hidden = true
     } else {
-      this.#hidden = false
-      this.setAttribute('aria-hidden', 'false')
+      this.hidden = false
     }
   }
 


### PR DESCRIPTION
This PR fixes:
- Issue when som elements gets `aria-hidden` even though they are in focus
- Issue with Popover positioning obscuring the input field when using the `combobox` option.