### PR TITLE
Text: add `overflow-wrap`

### DIFF
--- a/.changeset/rotten-numbers-vanish.md
+++ b/.changeset/rotten-numbers-vanish.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-core': patch
 ---
 
-**Text:** add overflow-word prop
+**Text:** add overflow-wrap prop

--- a/.changeset/rotten-numbers-vanish.md
+++ b/.changeset/rotten-numbers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Text:** add overflow-word prop

--- a/libs/core/src/components/div/div.ts
+++ b/libs/core/src/components/div/div.ts
@@ -213,6 +213,13 @@ export class GdsDiv extends withSizeXProps(
   'text-wrap'?: string
 
   /**
+   * Style Expression Property that controls the `overflow-wrap` property.
+   * Supports all valid CSS `overflow-wrap` values.
+   */
+  @styleExpressionProperty()
+  'overflow-wrap'?: string
+
+  /**
    * Style Expression Property that controls the `gap` property.
    * Only accepts space tokens.
    */

--- a/libs/core/src/components/text/text.stories.ts
+++ b/libs/core/src/components/text/text.stories.ts
@@ -279,3 +279,71 @@ export const Decoration: Story = {
       </gds-text>
     </gds-flex>`,
 }
+
+export const TextWrap: Story = {
+  name: 'Text Wrap',
+  render: (args) => html`
+    <gds-flex flex-direction="column" gap="m">
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">No wrap</gds-text>
+        <gds-text text-wrap="no-wrap">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">Pretty</gds-text>
+        <gds-text text-wrap="pretty">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">Pretty</gds-text>
+        <gds-text text-wrap="balance">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">Stable</gds-text>
+        <gds-text text-wrap="stable">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+    </gds-flex>
+  `,
+}
+
+export const OverflowWrap: Story = {
+  name: 'Overflow Wrap',
+  render: (args) => html`
+    <gds-flex flex-direction="column" gap="m">
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">Normal</gds-text>
+        <gds-text overflow-wrap="normal" font-size="heading-xl">
+          Most words are short & don't need to break. But
+          Antidisestablishmentarianism is long. The width is set to min-content,
+          with a max-width of 11em.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">Anywhere</gds-text>
+        <gds-text overflow-wrap="anywhere" font-size="heading-xl">
+          Most words are short & don't need to break. But
+          Antidisestablishmentarianism is long. The width is set to min-content,
+          with a max-width of 11em.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column" gap="m">
+        <gds-text tag="small" color="secondary">Break Word</gds-text>
+        <gds-text overflow-wrap="break-word" font-size="heading-xl">
+          Most words are short & don't need to break. But
+          Antidisestablishmentarianism is long. The width is set to min-content,
+          with a max-width of 11em.
+        </gds-text>
+      </gds-flex>
+    </gds-flex>
+  `,
+}

--- a/libs/core/src/components/text/text.stories.ts
+++ b/libs/core/src/components/text/text.stories.ts
@@ -155,49 +155,6 @@ export const Preamble: Story = {
 }
 
 /**
- * The `gds-text` component has a `lines` property that will clamp the text to the specified number of lines. It can be any number value.
- */
-export const Lines: Story = {
-  name: 'Line Clamp',
-  render: (args) => html`
-    <gds-flex flex-direction="column" gap="2xl">
-      <gds-flex flex-direction="column" gap="m">
-        <gds-divider></gds-divider>
-        <gds-text font-size="body-s">Lines:2</gds-text>
-        <gds-text font-size="display-s" lines="2">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </gds-text>
-      </gds-flex>
-      <gds-flex flex-direction="column" gap="m">
-        <gds-divider></gds-divider>
-        <gds-text font-size="body-s">Lines:3</gds-text>
-        <gds-text font-size="display-m" lines="3">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
-          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-          tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor
-          sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-          incididunt ut labore et dolore magna aliqua.
-        </gds-text>
-      </gds-flex>
-      <gds-flex flex-direction="column" gap="m">
-        <gds-divider></gds-divider>
-        <gds-text font-size="body-s">Lines:4</gds-text>
-        <gds-text font-size="display-l" lines="4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
-          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-          tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor
-          sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-          incididunt ut labore et dolore magna aliqua.
-        </gds-text>
-      </gds-flex>
-    </gds-flex>
-  `,
-}
-
-/**
  *
  * The `color` property that will change the text color based on the specified color token.
  *
@@ -280,33 +237,97 @@ export const Decoration: Story = {
     </gds-flex>`,
 }
 
-export const TextWrap: Story = {
-  name: 'Text Wrap',
+/**
+ * The `gds-text` component has a `lines` property that will clamp the text to the specified number of lines. It can be any number value.
+ */
+export const Lines: Story = {
+  name: 'Line Clamp',
   render: (args) => html`
-    <gds-flex flex-direction="column" gap="m">
+    <gds-flex flex-direction="column" gap="2xl">
       <gds-flex flex-direction="column" gap="m">
-        <gds-text tag="small" color="secondary">No wrap</gds-text>
-        <gds-text text-wrap="no-wrap">
+        <gds-divider></gds-divider>
+        <gds-text font-size="body-s">Lines:2</gds-text>
+        <gds-text font-size="display-s" lines="2">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </gds-text>
       </gds-flex>
       <gds-flex flex-direction="column" gap="m">
-        <gds-text tag="small" color="secondary">Pretty</gds-text>
+        <gds-divider></gds-divider>
+        <gds-text font-size="body-s">Lines:3</gds-text>
+        <gds-text font-size="display-m" lines="3">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor
+          sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column" gap="m">
+        <gds-divider></gds-divider>
+        <gds-text font-size="body-s">Lines:4</gds-text>
+        <gds-text font-size="display-l" lines="4">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor
+          sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+    </gds-flex>
+  `,
+}
+
+/**
+ *
+ * Check the documentation on `text-wrap` property [here](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap)
+ *
+ * The `text-wrap` property will change the text wrapping behavior based on the css values such as `wrap`, `nowrap`, `pretty`, `balance`, `stable`.
+ *
+ * e.g.
+ *
+ * ```html
+ * <gds-text text-wrap="pretty">
+ *    ...
+ * </gds-text>
+ * ```
+ */
+export const TextWrap: Story = {
+  name: 'text-wrap',
+  render: (args) => html`
+    <gds-flex flex-direction="column" gap="m" width="250px">
+      <gds-flex flex-direction="column">
+        <gds-text tag="small" color="secondary"><code>wrap</code></gds-text>
+        <gds-text text-wrap="wrap">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column">
+        <gds-text tag="code" color="secondary">nowrap</gds-text>
+        <gds-text text-wrap="nowrap">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </gds-text>
+      </gds-flex>
+      <gds-flex flex-direction="column">
+        <gds-text tag="code" color="secondary">pretty</gds-text>
         <gds-text text-wrap="pretty">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </gds-text>
       </gds-flex>
-      <gds-flex flex-direction="column" gap="m">
-        <gds-text tag="small" color="secondary">Pretty</gds-text>
+      <gds-flex flex-direction="column">
+        <gds-text tag="code" color="secondary">balance</gds-text>
         <gds-text text-wrap="balance">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </gds-text>
       </gds-flex>
-      <gds-flex flex-direction="column" gap="m">
-        <gds-text tag="small" color="secondary">Stable</gds-text>
+      <gds-flex flex-direction="column">
+        <gds-text tag="code" color="secondary">stable</gds-text>
         <gds-text text-wrap="stable">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -316,11 +337,25 @@ export const TextWrap: Story = {
   `,
 }
 
+/**
+ *
+ * Check the documentation on `text-overflow` property [here](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow)
+ *
+ * The `text-overflow` property will change the text overflow behavior based on the css values such as `clip`, `ellipsis`, `string`.
+ *
+ * e.g.
+ *
+ * ```html
+ * <gds-text overflow-wrap="break-word">
+ *    ...
+ * </gds-text>
+ * ```
+ */
 export const OverflowWrap: Story = {
-  name: 'Overflow Wrap',
+  name: 'overflow-wrap',
   render: (args) => html`
     <gds-flex flex-direction="column" gap="m">
-      <gds-flex flex-direction="column" gap="m">
+      <gds-flex flex-direction="column">
         <gds-text tag="small" color="secondary">Normal</gds-text>
         <gds-text overflow-wrap="normal" font-size="heading-xl">
           Most words are short & don't need to break. But
@@ -328,7 +363,7 @@ export const OverflowWrap: Story = {
           with a max-width of 11em.
         </gds-text>
       </gds-flex>
-      <gds-flex flex-direction="column" gap="m">
+      <gds-flex flex-direction="column">
         <gds-text tag="small" color="secondary">Anywhere</gds-text>
         <gds-text overflow-wrap="anywhere" font-size="heading-xl">
           Most words are short & don't need to break. But
@@ -336,7 +371,7 @@ export const OverflowWrap: Story = {
           with a max-width of 11em.
         </gds-text>
       </gds-flex>
-      <gds-flex flex-direction="column" gap="m">
+      <gds-flex flex-direction="column">
         <gds-text tag="small" color="secondary">Break Word</gds-text>
         <gds-text overflow-wrap="break-word" font-size="heading-xl">
           Most words are short & don't need to break. But

--- a/libs/core/src/components/text/text.ts
+++ b/libs/core/src/components/text/text.ts
@@ -72,6 +72,7 @@ export class GdsText extends GdsDiv {
    * Controls the number of lines it should show.
    */
   @styleExpressionProperty({
+    selector: '[tag]',
     styleTemplate: (_prop, values) => {
       return `overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
This PR adds a new property on the `gds-div` by extension making it available on the `gds-text` component. 
Also the ellipsis style it's passed now to the `[tag]` instead of the host in order to make ellipsis same font size as the content. 