### PR TITLE
Repo-Tools: New component fixes

### DIFF
--- a/libs/repo-tools/src/generators/core-component/files/__fileName__.stories.ts.template
+++ b/libs/repo-tools/src/generators/core-component/files/__fileName__.stories.ts.template
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/web-components'
 
 import './<%= toKebabCase(name) %>'
+import './<%= toBritishTitleCase(name) %>'
+import './<%= toPascalCase(name) %>'
 
 import { html } from 'lit'
 
 const meta: Meta = {
-  title: 'Components/<%= name %>',
+  title: 'Components/<%= toBritishTitleCase(name) %>',
   component: 'gds-<%= toKebabCase(name) %>',
   tags: ['autodocs'],
 }
@@ -25,7 +27,7 @@ const DefaultParams: Story = {
 /**
  * TODO: Add documentation
  */
-export const <%= name %>: Story = {
+export const <%= toPascalCase(name) %>: Story = {
   ...DefaultParams,
   name: '<%= name %>',
 }

--- a/libs/repo-tools/src/generators/core-component/generator.ts
+++ b/libs/repo-tools/src/generators/core-component/generator.ts
@@ -13,10 +13,26 @@ function toCamelCase(str: string): string {
 
 function toPascalCase(str: string): string {
   return str
+    .replace(/[^a-zA-Z0-9\s]/g, ' ')
     .replace(/(?:^\w|[A-Z]|\b\w)/g, (letter, index) => {
       return letter.toUpperCase()
     })
     .replace(/\s+/g, '')
+}
+
+function toBritishTitleCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((word, index) =>
+      index === 0
+        ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+        : word.toLowerCase(),
+    )
+    .join(' ')
 }
 
 function toKebabCase(str: string): string {
@@ -29,11 +45,19 @@ export async function coreComponentGenerator(
 ) {
   const componentRoot =
     `libs/core/src/` + options.componentType + 's/' + toKebabCase(options.name)
+
+  if (tree.exists(componentRoot)) {
+    throw new Error(
+      `A component with the name "${options.name}" already exists at "${componentRoot}". Please choose a different name.`,
+    )
+  }
+
   generateFiles(tree, path.join(__dirname, 'files'), componentRoot, {
     ...options,
     toCamelCase,
     toPascalCase,
     toKebabCase,
+    toBritishTitleCase,
     fileName: toKebabCase(options.name),
   })
   await formatFiles(tree)


### PR DESCRIPTION
Improved the name of the new component to use British title and pascal case in 2 places. Also aborts if component with that name already exists.