### PR TITLE
fix: restructured styling

### DIFF
--- a/libs/angular/src/v-angular/input/input.component.scss
+++ b/libs/angular/src/v-angular/input/input.component.scss
@@ -13,31 +13,29 @@
   --sg-border-width: 1px;
   --sg-border-color: #868686;
 
+  @include form-group.add-form-item();
+
   * {
     box-sizing: border-box;
   }
 
-  &.gds-form-item {
-    @include form-group.add-form-item();
+  .gds-form-item__footer {
+    .form-info {
+      font-weight: 500;
 
-    .gds-form-item__footer:not(:empty) {
-      .form-info {
-        font-weight: 500;
-      }
-
-      .form-info--error {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.5em;
-        color: #9f000a;
-
-        .error-icon {
-          align-items: center;
-        }
-      }
-
-      > .form-info--countdown {
+      &.form-info--countdown {
         font-weight: 400;
+      }
+    }
+
+    .form-info--error {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5em;
+      color: #9f000a;
+
+      .error-icon {
+        align-items: center;
       }
     }
   }


### PR DESCRIPTION
## Fix

`.gds-form-item` was never applied since no element with that class exists in the input-html. Restructured the css-classes to match the html (and that of other nggv-input-components).