### PR TITLE
Fix Textarea crash in Angular

### DIFF
--- a/.changeset/dull-falcons-vanish.md
+++ b/.changeset/dull-falcons-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Textarea:** Fix crash that would occur with Angular when using `clearable` option on textareas

--- a/libs/core/src/primitives/field-base/field-base.component.ts
+++ b/libs/core/src/primitives/field-base/field-base.component.ts
@@ -117,26 +117,17 @@ export class GdsFieldBase extends GdsElement {
   }
 
   #renderFieldContents() {
-    if (
-      this.multiline &&
-      (this._trailSlotOccupied || this._actionSlotOccupied)
-    ) {
-      return html`
-        ${this.#renderSlotLead()} ${this.#renderSlotMain()}
-        <div class="right">
-          ${this.#renderSlotAction()} ${this.#renderSlotTrail()}
-        </div>
-      `
-    } else {
-      const elements = [
-        this.#renderSlotLead(),
-        this.#renderSlotMain(),
-        this.#renderSlotAction(),
-        this.#renderSlotTrail(),
-      ]
-
-      return html`${map(elements, (el) => el)}`
+    const rightSlotsWrapClasses = {
+      right: true,
+      'as-flex':
+        this.multiline && (this._trailSlotOccupied || this._actionSlotOccupied),
     }
+    return html`
+      ${this.#renderSlotLead()} ${this.#renderSlotMain()}
+      <div class="${classMap(rightSlotsWrapClasses)}">
+        ${this.#renderSlotAction()} ${this.#renderSlotTrail()}
+      </div>
+    `
   }
 
   #renderSlotLead() {

--- a/libs/core/src/primitives/field-base/field-base.styles.ts
+++ b/libs/core/src/primitives/field-base/field-base.styles.ts
@@ -38,6 +38,10 @@ export const styles = css`
       transition-property: background-color;
 
       .right {
+        display: contents;
+      }
+
+      .right.as-flex {
         display: flex;
         position: absolute;
         gap: var(--gds-space-xs);


### PR DESCRIPTION
Conditionally changing DOM structure around slots likely caused a recursion of slotchange events, which may have tripped up ZoneJs in Angular.

Changing to a conditional classname solves the issue.