### PR TITLE
Updated v-angular table for mobile view

### DIFF
--- a/.changeset/proud-planes-allow.md
+++ b/.changeset/proud-planes-allow.md
@@ -1,5 +1,5 @@
 ---
-'@sebgroup/green-angular': patch
+'@sebgroup/green-angular': minor
 ---
 
 Updated v-angular table for mobile view

--- a/.changeset/proud-planes-allow.md
+++ b/.changeset/proud-planes-allow.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+Updated v-angular table for mobile view

--- a/libs/angular/src/v-angular/table/table.component.html
+++ b/libs/angular/src/v-angular/table/table.component.html
@@ -136,19 +136,19 @@
               >
                 <svg
                   *ngIf="item.subItems.length > 0"
-                  width="18" height="14" viewBox="0 0 24 24" fill="none"
+                  width="20" height="20" viewBox="0 0 24 24" fill="none"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
                     d="M20 9L12 17L4 9"
                     stroke="currentColor"
-                    stroke-width="2.6"
+                    stroke-width="1.6"
                     stroke-linecap="round"
                     stroke-linejoin="round"
                   />
                 </svg>
               </span>
-              {{ item[column.property] }} ({{ item.subItems.length }})
+                {{ item[column.property] }} ({{ item.subItems.length }})
             </div>
           </ng-container>
 
@@ -169,6 +169,7 @@
         <tr *ngFor="let subItem of item[subItemsProp]">
           <td
             *ngFor="let column of tableColumns"
+            class="web-view"
             [columnType]="column.valueType"
             [value]="subItem[column.property]"
             (click)="propagateItemClick(subItem, column.preventDefaultClickEvent)"
@@ -180,6 +181,54 @@
             <ng-template #defaultTdTemplate>
               {{ subItem[column.property] }}
             </ng-template>
+          </td>
+
+          <td class="mobile-view" [attr.colspan]="tableColumns.length">
+            <dl class="mobile-view-field-wrap">
+              <ng-container *ngFor="let column of tableColumns">
+                <div
+                  *ngIf="!column.hidePropertyOnMobile"
+                  class="mobile-view-field"
+                  [columnType]="column.valueType"
+                  [value]="subItem[column.property]"
+                  (click)="propagateItemClick(subItem, column.preventDefaultClickEvent)"
+                >
+                  <dt *ngIf="!column.hideLabelOnMobile">
+                    <ng-container *transloco="let t">
+                      {{ t(column.label ?? '') }}
+                    </ng-container>
+                  </dt>
+                  <dd>
+                    <strong>
+                      <ng-container *ngIf="customRowTemplates.get(column.property) as tdTemplate; else defaultTdTemplate">
+                        <ng-template *ngTemplateOutlet="tdTemplate; context: { $implicit: subItem }"></ng-template>
+                      </ng-container>
+                      <ng-template #defaultTdTemplate>
+                        {{ subItem[column.property] }}
+                      </ng-template>
+                    </strong>
+                  </dd>
+                  <ng-content></ng-content>
+                </div>
+              </ng-container>
+            </dl>
+            <span
+              class="nav-chevron-field"
+              [attr.aria-expanded]="rowSelectors.get(item[rowId])?.value"
+            >
+              <svg
+                width="20" height="20" viewBox="0 0 24 24" fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20 9L12 17L4 9"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
           </td>
         </tr>
       </ng-container>

--- a/libs/angular/src/v-angular/table/table.component.scss
+++ b/libs/angular/src/v-angular/table/table.component.scss
@@ -27,6 +27,14 @@
 
   border-bottom: none;
 
+  .web-view {
+    display: table-cell;
+  }
+
+  .mobile-view {
+    display: none;
+  }
+
   tr:hover td {
     background-color: var(--gds-ref-pallet-base100);
   }
@@ -43,7 +51,7 @@
   th,
   td {
     &.gds-table__numeric-col + :not(.gds-table__numeric-col) {
-      padding-left: 1rem;
+      // padding-left: 1rem;
     }
   }
 
@@ -170,6 +178,84 @@
       box-shadow: inset 0 0 0 1px #ababab;
       &::after {
         border-color: #ababab;
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 576px) {
+  .gds-table {
+    thead {
+      display: none;
+    }
+
+    tbody tr td {
+      border-top: none;
+      border-bottom: var(--sg-table-border-width) solid var(--sg-table-border-color);
+    }
+
+    .row__expand td:not(:first-child) {
+      display: none;
+    }
+
+    .row__expand td {
+      display: table-cell;
+    }
+
+    .web-view {
+      display: none;
+    }
+
+    .mobile-view {
+      display: flex;
+      align-items: center;
+
+      .mobile-view-field-wrap {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        width: 100%;
+
+        .mobile-view-field {
+          display: flex;
+          flex-direction: column;
+          padding-bottom: 0.3rem;
+
+          &:nth-child(2n + 1) {
+            justify-self: start;
+            align-items: start;
+          }
+
+          &:nth-child(2n) {
+            align-items: end;
+            justify-self: end;
+          }
+        }
+      }
+
+      .nav-chevron-field {
+        width: 1.5rem;
+        padding-left: 0.5rem;
+
+        svg {
+          transition: transform 0.3s ease;
+        }
+
+        &[aria-expanded='true'] svg {
+          transform: rotate(-90deg);
+        }
+      }
+
+      .settings-field {
+        width: 1.5rem;
+        padding: 0 1rem;
+
+        svg {
+          transition: all 0.3s ease;
+        }
+
+        &:hover svg {
+          fill: var(--gds-sys-color-blue-dark-2);
+        }
       }
     }
   }

--- a/libs/angular/src/v-angular/table/table.mock.ts
+++ b/libs/angular/src/v-angular/table/table.mock.ts
@@ -1,6 +1,15 @@
 import { Observable, of } from 'rxjs'
 
-import { TableColumn } from './table.models'
+export interface TableColumn<T> {
+  property: keyof T;
+  label: string;
+  sortable?: boolean;
+  valueType?: 'numeric' | 'text';
+  order?: 'asc' | 'desc';
+  ariaLabelSortable?: string;
+  hidePropertyOnMobile?: boolean;
+  hideLabelOnMobile?: boolean;
+}
 
 export type ColumnData = {
   id: string
@@ -73,23 +82,27 @@ export const columns: {
     {
       property: 'name',
       label: 'header.name',
+      hideLabelOnMobile: true,
+    },
+    {
+      property: 'status',
+      label: 'header.status',
+      hideLabelOnMobile: true,
     },
     {
       property: 'currency',
       label: 'header.currency',
     },
     {
-      property: 'status',
-      label: 'header.status',
-    },
-    {
       property: 'bookedBalance',
+      hidePropertyOnMobile: true,
       label: 'header.bookedbalance',
       valueType: 'numeric',
     },
     {
       property: 'datedBalance',
       label: 'header.datedbalance',
+      hidePropertyOnMobile: true,
       valueType: 'numeric',
     },
     {
@@ -99,6 +112,7 @@ export const columns: {
     },
     {
       property: 'unauthorizedUsage',
+      hidePropertyOnMobile: true,
       label: 'header.unauthorizedusage',
       valueType: 'numeric',
     },

--- a/libs/angular/src/v-angular/table/table.mock.ts
+++ b/libs/angular/src/v-angular/table/table.mock.ts
@@ -1,15 +1,6 @@
 import { Observable, of } from 'rxjs'
 
-export interface TableColumn<T> {
-  property: keyof T;
-  label: string;
-  sortable?: boolean;
-  valueType?: 'numeric' | 'text';
-  order?: 'asc' | 'desc';
-  ariaLabelSortable?: string;
-  hidePropertyOnMobile?: boolean;
-  hideLabelOnMobile?: boolean;
-}
+import { TableColumn } from './table.models'
 
 export type ColumnData = {
   id: string

--- a/libs/angular/src/v-angular/table/table.models.ts
+++ b/libs/angular/src/v-angular/table/table.models.ts
@@ -32,6 +32,12 @@ export interface TableHeaderOptions {
    * it will instruct the table to sort the data based on this specific column.
    */
   order?: SortingOrder
+
+  /**
+   * Dynamically hide or show the label and data on mobile view.
+   */
+  hideLabelOnMobile?: boolean
+  hidePropertyOnMobile?: boolean
 }
 
 /** Options applying to table rows */


### PR DESCRIPTION
At the moment, the v-angular table is not adapted for mobile layouts, but our MFEs now require it. So, I decided to update the current table component layout according to the provided sketches. Later, it might be better to have a different component, similar to an accordion or something similar, but for now, I believe these changes will be sufficient.

The idea is to switch the regular table to one with expandable functionality on mobile views. However, table data modification and table settings will be controlled from the MFE side, depending on screen size. From the library side, only the layout will be updated. If the table is already expandable, no additional logic is required.

Required functionality:  

- Dynamically hide/show labels and data

![image](https://github.com/user-attachments/assets/62bdb26b-356b-41d5-86d7-eddc7f532aca)
![image](https://github.com/user-attachments/assets/0a570347-0d77-4bd9-b3de-0125fec5d171)
![image](https://github.com/user-attachments/assets/3d858dcd-aa14-4995-bdf0-e10197bf001d)

Web view (already exists):
![image](https://github.com/user-attachments/assets/557bfbe9-860c-4d40-b2a8-d1ef4b506f82)

Mobile view (now updated to have):

1. ![image](https://github.com/user-attachments/assets/5dcf8e0e-81af-4d08-a261-d8c3a965c8f7)

1. ![image](https://github.com/user-attachments/assets/725a06ab-9e70-4caa-ac3f-6f1ddec19a2f)




