### PR TITLE
InputFields: Custom Locked Template

### DIFF
--- a/libs/angular/src/v-angular/base-control-value-accessor/base-control-value-accessor.component.ts
+++ b/libs/angular/src/v-angular/base-control-value-accessor/base-control-value-accessor.component.ts
@@ -41,6 +41,12 @@ export class NggvBaseControlValueAccessorComponent
   @ContentChild('labelTpl', { read: TemplateRef })
   labelContentTpl?: TemplateRef<undefined>
 
+  /** Custom template for displaying value when the input is locked.
+   * Specified by nesting an `<ng-template #lockedTpl let-state>Custom locked content state: {{ state }}</ng-template>`.
+   */
+  @ContentChild('lockedTpl', { read: TemplateRef })
+  lockedTpl?: TemplateRef<undefined>
+
   /** Reference to the native child input element. */
   @ViewChild('input', { read: ElementRef }) inputRef?: ElementRef
 

--- a/libs/angular/src/v-angular/button/button.stories.ts
+++ b/libs/angular/src/v-angular/button/button.stories.ts
@@ -88,6 +88,7 @@ export const Primary = Template.bind({})
 Primary.args = {
   buttonStyle: ButtonStyle.Primary,
   text: getButtonText(ButtonStyle.Primary),
+  small: false,
   clickAction: console.log,
 }
 

--- a/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.html
+++ b/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.html
@@ -32,18 +32,26 @@
 
   <!-- LOCKED INPUT -->
   <ng-container *ngIf="locked">
-    <div
-      [id]="id + '-input'"
-      class="nggv-field--locked"
-      [attr.name]="name"
-      [attr.value]="state"
-      [attr.role]="role"
-    >
-      <span *ngIf="!state" class="unset-state">-</span>
-      <ng-container *ngIf="state">
-        {{ state | nggvInputMaskFormat: dateInputMask }}
-      </ng-container>
-    </div>
+    <ng-template
+      *ngTemplateOutlet="
+        lockedTpl || defaultLockedTpl;
+        context: { $implicit: state }
+      "
+    ></ng-template>
+    <ng-template #defaultLockedTpl>
+      <div
+        [id]="id + '-input'"
+        class="nggv-field--locked"
+        [attr.name]="name"
+        [attr.value]="state"
+        [attr.role]="role"
+      >
+        <span *ngIf="!state" class="unset-state">-</span>
+        <ng-container *ngIf="state">
+          {{ state | nggvInputMaskFormat: dateInputMask }}
+        </ng-container>
+      </div>
+    </ng-template>
   </ng-container>
 
   <!-- INPUT WRAPPER -->

--- a/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.ts
+++ b/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.ts
@@ -15,7 +15,6 @@ import {
   ViewChild,
 } from '@angular/core'
 import { NgControl } from '@angular/forms'
-// import { faCalendarDays, IconDefinition } from '@fortawesome/pro-regular-svg-icons';
 import {
   TRANSLOCO_SCOPE,
   TranslocoScope,

--- a/libs/angular/src/v-angular/datepicker/date-control-value-accessor/date-control-value-accessor.component.ts
+++ b/libs/angular/src/v-angular/datepicker/date-control-value-accessor/date-control-value-accessor.component.ts
@@ -61,6 +61,12 @@ export abstract class DateControlValueAccessorComponent
   @ContentChild('labelTpl', { read: TemplateRef })
   labelContentTpl?: TemplateRef<undefined>
 
+  /** Custom template for displaying value when the input is locked.
+   * Specified by nesting an `<ng-template #lockedTpl let-selectedDate>Custom locked content date: {{ selectedDate }}</ng-template>`.
+   */
+  @ContentChild('lockedTpl', { read: TemplateRef })
+  lockedTpl?: TemplateRef<undefined>
+
   /** Reference to the native child input element. */
   @ViewChild('input', { read: ElementRef }) inputRef?: ElementRef
 

--- a/libs/angular/src/v-angular/datepicker/datepicker.stories.ts
+++ b/libs/angular/src/v-angular/datepicker/datepicker.stories.ts
@@ -384,6 +384,43 @@ const TemplateWithTwoInputs: StoryFn<DateStoryArgs> = (args) => {
   }
 }
 
+const CustomLockedTemplate: StoryFn<DateStoryArgs & any> = (args) => {
+  const dateFc = new UntypedFormControl(args.ngModel)
+
+  dateFc.valueChanges.subscribe((val) => {
+    console.log('control value:', val)
+  })
+
+  // remove non-input args
+  return {
+    template: /*html*/ `
+    <nggv-dateinput
+      [label]="label"
+      [locale]="locale"
+      [dateLocale]="dateLocale"
+      [disableDates]="disableDates"
+      [disableWeekDays]="disableWeekDays"
+      [required]="required"
+      [invalid]="invalid"
+      [error]="error"
+      [errorList]="errorList"
+      [withErrorIcon]="withErrorIcon"
+      [firstDayOfWeek]="firstDayOfWeek"
+      [formControl]="formControl"
+      [locked]="locked"
+      [displayDisabledAsLocked]="displayDisabledAsLocked"
+      [closeCalendarOnEscape]="closeCalendarOnEscape"
+      >
+      <ng-template #lockedTpl let-state>Today ({{ state | date: 'shortDate' }})</ng-template>
+    </nggv-dateinput>
+    `,
+    props: {
+      ...args,
+      formControl: dateFc,
+    },
+  }
+}
+
 export const Primary = PrimaryTemplate.bind({})
 Primary.args = {
   label: 'Date label',
@@ -488,6 +525,15 @@ WithTwoControls.args = {
 export const WithLockedInput = PrimaryTemplate.bind({})
 WithLockedInput.args = {
   ...Primary.args,
+  locked: true,
+  description: undefined,
+  displayDisabledAsLocked: false,
+}
+
+export const WithCustomLockedTemplate = CustomLockedTemplate.bind({})
+WithCustomLockedTemplate.args = {
+  ...Primary.args,
+  ngModel: new Date(),
   locked: true,
   description: undefined,
   displayDisabledAsLocked: false,

--- a/libs/angular/src/v-angular/dropdown/dropdown.component.html
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.html
@@ -28,25 +28,33 @@
 
   <!-- LOCKED INPUT -->
   <ng-container *ngIf="locked">
-    <div
-      [id]="id + '-input'"
-      class="nggv-field--locked"
-      [attr.name]="name"
-      [attr.value]="state"
-      [attr.role]="role"
-      [attr.aria-labelledby]="id + '-label ' + id + '-input'"
-    >
-      <span *ngIf="!state" class="unset-state">-</span>
-      <ng-container *ngIf="state">
-        <ng-template
-          *ngTemplateOutlet="
-            selectedContentTpl || defaultSelectedContentTpl;
-            context: { $implicit: state }
-          "
-        >
-        </ng-template>
-      </ng-container>
-    </div>
+    <ng-template
+      *ngTemplateOutlet="
+        lockedTpl || defaultLockedTpl;
+        context: { $implicit: state }
+      "
+    ></ng-template>
+    <ng-template #defaultLockedTpl>
+      <div
+        [id]="id + '-input'"
+        class="nggv-field--locked"
+        [attr.name]="name"
+        [attr.value]="state"
+        [attr.role]="role"
+        [attr.aria-labelledby]="id + '-label ' + id + '-input'"
+      >
+        <span *ngIf="!state" class="unset-state">-</span>
+        <ng-container *ngIf="state">
+          <ng-template
+            *ngTemplateOutlet="
+              selectedContentTpl || defaultSelectedContentTpl;
+              context: { $implicit: state }
+            "
+          >
+          </ng-template>
+        </ng-container>
+      </div>
+    </ng-template>
   </ng-container>
 
   <!-- INPUT -->

--- a/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
@@ -662,6 +662,14 @@ WithLockedInput.args = {
   description: undefined,
 }
 
+export const WithCustomLockedTemplate = Template.bind({})
+WithCustomLockedTemplate.args = {
+  ...Primary.args,
+  ngModel: 'opt2',
+  locked: true,
+  description: undefined,
+}
+
 export const WithDisplayDisabledAsLocked = Template.bind({})
 WithDisplayDisabledAsLocked.args = {
   ...Primary.args,

--- a/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
@@ -662,14 +662,6 @@ WithLockedInput.args = {
   description: undefined,
 }
 
-export const WithCustomLockedTemplate = Template.bind({})
-WithCustomLockedTemplate.args = {
-  ...Primary.args,
-  ngModel: 'opt2',
-  locked: true,
-  description: undefined,
-}
-
 export const WithDisplayDisabledAsLocked = Template.bind({})
 WithDisplayDisabledAsLocked.args = {
   ...Primary.args,

--- a/libs/angular/src/v-angular/input/input.component.html
+++ b/libs/angular/src/v-angular/input/input.component.html
@@ -32,23 +32,31 @@
 
 <!-- LOCKED INPUT -->
 <ng-container *ngIf="locked">
-  <div
-    [id]="id + '-input'"
-    class="nggv-field--locked"
-    [attr.name]="name"
-    [attr.value]="state"
-    [attr.role]="role"
-  >
-    <span *ngIf="!state" class="unset-state">-</span>
-    <ng-container *ngIf="state">
-      <ng-container *ngIf="!inputMask">
-        {{ state }}
+  <ng-template
+    *ngTemplateOutlet="
+      lockedTpl || defaultLockedTpl;
+      context: { $implicit: state }
+    "
+  ></ng-template>
+  <ng-template #defaultLockedTpl>
+    <div
+      [id]="id + '-input'"
+      class="nggv-field--locked"
+      [attr.name]="name"
+      [attr.value]="state"
+      [attr.role]="role"
+    >
+      <span *ngIf="!state" class="unset-state">-</span>
+      <ng-container *ngIf="state">
+        <ng-container *ngIf="!inputMask">
+          {{ state }}
+        </ng-container>
+        <ng-container *ngIf="!!inputMask">
+          {{ state | nggvInputMaskFormat: inputMask }}
+        </ng-container>
       </ng-container>
-      <ng-container *ngIf="!!inputMask">
-        {{ state | nggvInputMaskFormat: inputMask }}
-      </ng-container>
-    </ng-container>
-  </div>
+    </div>
+  </ng-template>
 </ng-container>
 
 <!-- INPUT WRAPPER -->

--- a/libs/angular/src/v-angular/textarea/textarea.component.html
+++ b/libs/angular/src/v-angular/textarea/textarea.component.html
@@ -29,18 +29,26 @@
 
 <!-- LOCKED INPUT -->
 <ng-container *ngIf="locked">
-  <div
-    [id]="id + '-textarea'"
-    class="nggv-field--locked"
-    [attr.name]="name"
-    [attr.value]="state"
-    [attr.role]="role"
-  >
-    <span *ngIf="!state" class="unset-state">-</span>
-    <ng-container *ngIf="state">
-      {{ state }}
-    </ng-container>
-  </div>
+  <ng-template
+    *ngTemplateOutlet="
+      lockedTpl || defaultLockedTpl;
+      context: { $implicit: state }
+    "
+  ></ng-template>
+  <ng-template #defaultLockedTpl>
+    <div
+      [id]="id + '-textarea'"
+      class="nggv-field--locked"
+      [attr.name]="name"
+      [attr.value]="state"
+      [attr.role]="role"
+    >
+      <span *ngIf="!state" class="unset-state">-</span>
+      <ng-container *ngIf="state">
+        {{ state }}
+      </ng-container>
+    </div>
+  </ng-template>
 </ng-container>
 
 <!-- INPUT FIELD -->


### PR DESCRIPTION
## Feature

Allow a custom template to be used for when the input (nggv-input, nggv-dropdown, nggv-textarea, nggv-date-input) is in a locked state.

If not sent in, `#defaultLockedTpl` will be used.

This in order to support below use-case (show a text together with the value of the input):
![image](https://github.com/user-attachments/assets/8e9ff50b-5f7b-4384-9e06-2eb3c807d224)

### How to use

Selected state is forwarded via `$implicit` context.

```html
<nggv-dateinput>
  <ng-template #lockedTpl let-selectedDate>Today ({{ selectedDate | date: 'shortDate' }})</ng-template>
</nggv-dateinput>

```

## Fix

Added toggle input for `small` in nggv-button story.