### PR TITLE
Adding sizing tokens for transitional styles

### DIFF
--- a/.changeset/sharp-phones-poke.md
+++ b/.changeset/sharp-phones-poke.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/chlorophyll': patch
+---
+
+Add missing sizing tokens for transitional styles

--- a/libs/chlorophyll/scss/components/themes/_index.scss
+++ b/libs/chlorophyll/scss/components/themes/_index.scss
@@ -2,6 +2,7 @@
 @use '../../tokens/components' as components;
 @use '../../tokens/colors' as colors;
 @use '../../tokens/shape' as shape;
+@use '../../tokens/size';
 @use 'mixins';
 
 /* force dark mode to whole app or part of it by adding the class ".dark-mode" */
@@ -20,6 +21,7 @@
 
 /* apps will use light mode by default */
 :root {
+  @include size.add-tokens;
   @include shape.add-tokens;
   @include colors.add-color-tokens;
   @include components.add-checkbox-tokens;

--- a/libs/chlorophyll/scss/components/use-green-scope/_index.scss
+++ b/libs/chlorophyll/scss/components/use-green-scope/_index.scss
@@ -8,12 +8,14 @@ $use-green-selector: '.use-green' !default;
 @use '../../tokens/colors';
 @use '../../tokens/components';
 @use '../../tokens/shape';
+@use '../../tokens/size';
 
 @use '../reset/mixins' as mixins;
 @use '../themes/mixins' as themes;
 
 /* add variables for light mode to `.use-green` class */
 #{$use-green-selector} {
+  @include size.add-tokens();
   @include shape.add-tokens();
   @include colors.add-color-tokens();
   @include components.add-radio-tokens();

--- a/libs/chlorophyll/scss/tokens/_size.scss
+++ b/libs/chlorophyll/scss/tokens/_size.scss
@@ -1,0 +1,19 @@
+@mixin add-tokens() {
+  --gds-sys-space-0: 0px;
+  --gds-sys-space-4xs: 1px;
+  --gds-sys-space-3xs: 2px;
+  --gds-sys-space-2xs: 4px;
+  --gds-sys-space-xs: 8px;
+  --gds-sys-space-s: 12px;
+  --gds-sys-space-m: 16px;
+  --gds-sys-space-l: 24px;
+  --gds-sys-space-xl: 32px;
+  --gds-sys-space-2xl: 40px;
+  --gds-sys-space-3xl: 48px;
+  --gds-sys-space-4xl: 64px;
+  --gds-sys-space-5xl: 80px;
+  --gds-sys-space-6xl: 96px;
+  --gds-sys-space-7xl: 112px;
+  --gds-sys-space-8xl: 120px;
+  --gds-sys-space-max: 999px;
+}

--- a/libs/chlorophyll/scss/tokens/_spacing.scss
+++ b/libs/chlorophyll/scss/tokens/_spacing.scss
@@ -1,6 +1,8 @@
 @use '../common/functions/bootstrap-functions' as functions;
 @use 'sass:map';
+
 $enable-negative-margins: true;
+
 $spacing: (
   0: 0,
   1: 0.125rem,


### PR DESCRIPTION
Issue can be seen here: https://storybook.seb.io/latest/angular/?path=/story/components-dropdown--select

<img width="758" alt="Screenshot 2025-05-05 at 15 54 24" src="https://github.com/user-attachments/assets/d6b1e21b-57f8-444c-a5a8-15d8e3a7d986" />
