### PR TITLE
MABFF-1090 Table a11y warnings

### DIFF
--- a/.changeset/brown-tools-care.md
+++ b/.changeset/brown-tools-care.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+Resolved V-Angular table a11y warnings

--- a/libs/angular/src/v-angular/table/table.component.html
+++ b/libs/angular/src/v-angular/table/table.component.html
@@ -129,13 +129,18 @@
           (click)="propagateItemClick(item, column.preventDefaultClickEvent)"
         >
         <ng-container *ngIf="expandable && i === 0; else nonExpandableTemplate">
-            <div class="gds-item-field-wrap">
+            <div
+              class="gds-item-field-wrap"
+              [ngClass]="{ 'no-sub-items': item.subItems.length === 0 }"
+              >
               <span
+                *ngIf="item.subItems.length > 0"
+                role="button"
+                tabindex="0"
                 class="chevron-field"
                 [attr.aria-expanded]="rowSelectors.get(item[rowId])?.value"
               >
                 <svg
-                  *ngIf="item.subItems.length > 0"
                   width="20" height="20" viewBox="0 0 24 24" fill="none"
                   xmlns="http://www.w3.org/2000/svg"
                 >
@@ -214,6 +219,8 @@
               </ng-container>
             </dl>
             <span
+              role="button"
+              tabindex="0"
               class="nav-chevron-field"
               [attr.aria-expanded]="rowSelectors.get(item[rowId])?.value"
             >

--- a/libs/angular/src/v-angular/table/table.component.html
+++ b/libs/angular/src/v-angular/table/table.component.html
@@ -132,7 +132,7 @@
             <div
               class="gds-item-field-wrap"
               [ngClass]="{ 'no-sub-items': item.subItems.length === 0 }"
-              >
+            >
               <span
                 *ngIf="item.subItems.length > 0"
                 role="button"

--- a/libs/angular/src/v-angular/table/table.component.scss
+++ b/libs/angular/src/v-angular/table/table.component.scss
@@ -129,6 +129,10 @@
         display: flex;
         flex-wrap: nowrap;
 
+        &.no-sub-items {
+          padding-left: 1.5rem;
+        }
+
         .chevron-field {
           width: 1.5rem;
 
@@ -180,7 +184,7 @@
   }
 }
 
-@media screen and (max-width: 576px) {
+@media screen and (max-width: 600px) {
   .gds-table {
     thead {
       display: none;


### PR DESCRIPTION
- Lighthouse was throwing accessibility warnings for the table.

- Updated the breakpoint pixel range for the mobile view according to Angular’s "@angular/cdk/layout".
