### PR TITLE
Update NggCoreControl directive selectors

### DIFF
--- a/.changeset/silver-bugs-hide.md
+++ b/.changeset/silver-bugs-hide.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+**NggCoreControl:** Update selectors to only apply when controls are used with reactive forms (when `formControlName` is present)

--- a/libs/angular/src/lib/shared/core-control/core-checkbox.directive.ts
+++ b/libs/angular/src/lib/shared/core-control/core-checkbox.directive.ts
@@ -4,7 +4,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
 import { NggCoreControlDirective } from './core-control.directive'
 
 @Directive({
-  selector: `gds-checkbox, [nggCoreCheckboxControl]`,
+  selector: `gds-checkbox[formControlName], [nggCoreCheckboxControl]`,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/libs/angular/src/lib/shared/core-control/core-control.directive.ts
+++ b/libs/angular/src/lib/shared/core-control/core-control.directive.ts
@@ -14,13 +14,13 @@ import {
 } from '@angular/forms'
 
 @Directive({
-  selector: `gds-input:not([ngDefaultControl]),
-     gds-textarea:not([ngDefaultControl]),
-     gds-dropdown:not([ngDefaultControl]),
-     gds-datepicker:not([ngDefaultControl]),
-     gds-select:not([ngDefaultControl]),
-     gds-radio-group:not([ngDefaultControl]),
-     gds-checkbox-group:not([ngDefaultControl]),
+  selector: `gds-input[formControlName]:not([ngDefaultControl]),
+     gds-textarea[formControlName]:not([ngDefaultControl]),
+     gds-dropdown[formControlName]:not([ngDefaultControl]),
+     gds-datepicker[formControlName]:not([ngDefaultControl]),
+     gds-select[formControlName]:not([ngDefaultControl]),
+     gds-radio-group[formControlName]:not([ngDefaultControl]),
+     gds-checkbox-group[formControlName]:not([ngDefaultControl]),
      [nggCoreControl]`,
   providers: [
     {

--- a/libs/angular/src/lib/shared/core-control/core-control.spec.ts
+++ b/libs/angular/src/lib/shared/core-control/core-control.spec.ts
@@ -26,6 +26,7 @@ import { NggCoreFormsModule } from './core-control.module'
         name="password"
         required
       ></gds-input>
+      <gds-input name="nonReactive" required></gds-input>
     </form>
   `,
 })
@@ -43,6 +44,7 @@ describe('NggCoreControlDirective', () => {
   let nameInputEl: DebugElement
   let emailInputEl: DebugElement
   let passwordInputEl: DebugElement
+  let nonReactiveInputEl: DebugElement
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -59,6 +61,9 @@ describe('NggCoreControlDirective', () => {
     )
     emailInputEl = fixture.debugElement.query(By.css('[name="email"]'))
     passwordInputEl = fixture.debugElement.query(By.css('[name="password"]'))
+    nonReactiveInputEl = fixture.debugElement.query(
+      By.css('[name="nonReactive"]'),
+    )
   })
 
   it('should set invalid property on the element', async () => {
@@ -138,5 +143,15 @@ describe('NggCoreControlDirective', () => {
     await fixture.whenStable()
 
     expect(passwordInputEl.nativeElement.invalid).toBe(false)
+  })
+
+  it('should not apply controlValueAccessor to non-reactive input', async () => {
+    const control = component.form.get('nonReactive')
+    control?.markAsDirty()
+    fixture.detectChanges()
+
+    await fixture.whenStable()
+
+    expect(nonReactiveInputEl.nativeElement.invalid).toBe(false)
   })
 })


### PR DESCRIPTION
This PR solves an issue where console errors appeared when green-core form controls where used in Angular outside of reactive forms (i.e, without `formControlName` directive)