### PR TITLE
Dropdown: Fix trigger label when custom template is used

### DIFF
--- a/.changeset/neat-bags-sort.md
+++ b/.changeset/neat-bags-sort.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Dropdown:** Fix aria-label issue when custom trigger template is used

--- a/libs/core/src/components/dropdown/dropdown.component.ts
+++ b/libs/core/src/components/dropdown/dropdown.component.ts
@@ -223,16 +223,16 @@ export class GdsDropdown<ValueT = any>
             .reduce(
               (acc: string, cur: ValueT) =>
                 acc +
-                this.options.find((v) => v.value === cur)?.innerHTML +
+                this.options.find((v) => v.value === cur)?.innerText +
                 ', ',
               '',
             )
             .slice(0, -2))
     } else {
-      displayValue = this.options.find((v) => v.selected)?.innerHTML
+      displayValue = this.options.find((v) => v.selected)?.innerText
     }
 
-    return displayValue || this.placeholder?.innerHTML || ''
+    return displayValue || this.placeholder?.innerText || ''
   }
 
   /**


### PR DESCRIPTION
Fixes issue where markup was included in the `aria-label` attribute and got read up in raw form by some screen readers.