### PR TITLE
Drag-drop: Prevent overflow for file name

### DIFF
--- a/.changeset/wide-planes-tap.md
+++ b/.changeset/wide-planes-tap.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-angular": patch
+---
+
+Dragdrop: Prevet overflow for file name

--- a/libs/angular/src/v-angular/drag-drop/drag-drop.component.scss
+++ b/libs/angular/src/v-angular/drag-drop/drag-drop.component.scss
@@ -20,6 +20,7 @@
     border: 2px dashed #868686;
     font-weight: 500;
     padding: 2.25em 1.5em;
+    overflow-wrap: anywhere;
   }
 
   .gds-drag-drop__input + .gds-drag-drop__label em {


### PR DESCRIPTION
Prevent file name of overflowing if it contains a string that can't be broken following "normal" line break rules.