### PR TITLE
MABFF-1150 From design review: Remove line/border around table header

### DIFF
--- a/.changeset/lovely-beers-care.md
+++ b/.changeset/lovely-beers-care.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+V-Angular: Removed the top line/border from the table header.

--- a/libs/chlorophyll/scss/components/table/_mixins.scss
+++ b/libs/chlorophyll/scss/components/table/_mixins.scss
@@ -24,7 +24,6 @@ $gray-800: map.get(map.get(tokens.$grey, light), 800);
   thead {
     tr {
       th {
-        border-top: $_border-width solid $_border-color;
         background: $_header-background;
         color: $_header-color;
         padding: $_table_header_padding;


### PR DESCRIPTION
After CX designer's review, there was a request to remove the table line/border around the table header.

![image](https://github.com/user-attachments/assets/48c01530-4be7-47ed-bd19-7fdc6a931891)
