### PR TITLE
GdsElement: Add helpers for React compatible event names

### DIFF
--- a/.changeset/curly-mirrors-joke.md
+++ b/.changeset/curly-mirrors-joke.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': minor
+---
+
+**GdsElement:** Add event dispatch helpers for dispatching compatible events

--- a/libs/core/custom-elements-manifest.config.mjs
+++ b/libs/core/custom-elements-manifest.config.mjs
@@ -45,26 +45,6 @@ export default {
         })
       },
     },
-    {
-      name: 'green-react-event-names',
-      analyzePhase({ ts, node, moduleDoc }) {
-        switch (node.kind) {
-          case ts.SyntaxKind.ClassDeclaration: {
-            const className = node.name.getText()
-            const classDoc = moduleDoc?.declarations?.find(
-              (declaration) => declaration.name === className,
-            )
-
-            if (classDoc?.events) {
-              classDoc.events.forEach((event) => {
-                event.reactName = `on${pascalCase(event.name)}`
-                event.eventName = `${pascalCase(event.name)}Event`
-              })
-            }
-          }
-        }
-      },
-    },
   ],
 }
 

--- a/libs/core/src/components/button/button.component.ts
+++ b/libs/core/src/components/button/button.component.ts
@@ -190,13 +190,11 @@ class Button extends GdsFormControlElement<any> {
   }
 
   #handleClick = (e: MouseEvent) => {
-    this.dispatchEvent(
-      new CustomEvent('gds-click', {
-        bubbles: true,
-        composed: true,
-        detail: e,
-      }),
-    )
+    this.dispatchCustomEvent('gds-click', {
+      bubbles: true,
+      composed: true,
+      detail: e,
+    })
 
     if (this.form && !this.#isLink) {
       if (this.type === 'submit') {

--- a/libs/core/src/components/calendar/calendar.component.ts
+++ b/libs/core/src/components/calendar/calendar.component.ts
@@ -342,13 +342,11 @@ export class GdsCalendar extends GdsElement {
 
     this.value = dateOnMidDay
 
-    this.dispatchEvent(
-      new CustomEvent('change', {
-        detail: dateOnMidDay,
-        bubbles: false,
-        composed: false,
-      }),
-    )
+    this.dispatchCustomEvent('change', {
+      detail: dateOnMidDay,
+      bubbles: false,
+      composed: false,
+    })
   }
 
   @watch('value')
@@ -397,14 +395,11 @@ export class GdsCalendar extends GdsElement {
       newFocusedDate.getFullYear() >= this.min.getFullYear() &&
       newFocusedDate.getFullYear() <= this.max.getFullYear()
     ) {
-      const proceed = this.dispatchEvent(
-        new CustomEvent('gds-date-focused', {
-          detail: newFocusedDate,
-          bubbles: false,
-          composed: false,
-          cancelable: true,
-        }),
-      )
+      const proceed = this.dispatchCustomEvent('gds-date-focused', {
+        detail: newFocusedDate,
+        bubbles: false,
+        composed: false,
+      })
       if (proceed) {
         this.focusedDate = newFocusedDate
       }

--- a/libs/core/src/components/checkbox/checkbox-group/checkbox-group.component.ts
+++ b/libs/core/src/components/checkbox/checkbox-group/checkbox-group.component.ts
@@ -164,12 +164,10 @@ class CheckboxGroup extends GdsFormControlElement<string[]> {
 
   #dispatchInputEvent() {
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new Event('input', {
-          bubbles: true,
-          composed: true,
-        }),
-      ),
+      this.dispatchStandardEvent('input', {
+        bubbles: true,
+        composed: true,
+      }),
     )
   }
 

--- a/libs/core/src/components/checkbox/checkbox.component.ts
+++ b/libs/core/src/components/checkbox/checkbox.component.ts
@@ -143,18 +143,14 @@ export class GdsCheckbox extends GdsFormControlElement {
     } else {
       this.checked = !this.checked
     }
-    this.dispatchEvent(
-      new Event('change', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
-    this.dispatchEvent(
-      new Event('input', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
+    this.dispatchStandardEvent('change', {
+      bubbles: true,
+      composed: true,
+    })
+    this.dispatchStandardEvent('input', {
+      bubbles: true,
+      composed: true,
+    })
   }
 
   protected _getValidityAnchor(): HTMLElement {

--- a/libs/core/src/components/coachmark/coachmark.component.ts
+++ b/libs/core/src/components/coachmark/coachmark.component.ts
@@ -125,13 +125,11 @@ export class GdsCoachmark extends GdsElement {
     this._isVisible = false
     this.#cardRef.value?.remove()
     this.#autoUpdateCleanupFn?.()
-    this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        detail: { open: this._isVisible, reason: 'closed' },
-        bubbles: false,
-        composed: false,
-      }),
-    )
+    this.dispatchCustomEvent('gds-ui-state', {
+      detail: { open: this._isVisible, reason: 'closed' },
+      bubbles: false,
+      composed: false,
+    })
   }
 
   #findTarget(selectors: string[]): HTMLElement | undefined {

--- a/libs/core/src/components/datepicker/date-part-spinner.ts
+++ b/libs/core/src/components/datepicker/date-part-spinner.ts
@@ -161,11 +161,9 @@ export class GdsDatePartSpinner extends GdsElement {
   }
 
   #dispatchChangeEvent() {
-    this.dispatchEvent(
-      new CustomEvent('change', {
-        detail: { value: this.value.toString() },
-      }),
-    )
+    this.dispatchCustomEvent('change', {
+      detail: { value: this.value.toString() },
+    })
   }
 
   #formatNumber(num: number | string, padZeros: number) {

--- a/libs/core/src/components/datepicker/datepicker.component.ts
+++ b/libs/core/src/components/datepicker/datepicker.component.ts
@@ -613,23 +613,19 @@ class Datepicker extends GdsFormControlElement<Date> {
 
   #dispatchChangeEvent() {
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new Event('change', {
-          bubbles: true,
-          composed: true,
-        }),
-      ),
+      this.dispatchStandardEvent('change', {
+        bubbles: true,
+        composed: true,
+      }),
     )
   }
 
   #dispatchInputEvent() {
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new Event('input', {
-          bubbles: true,
-          composed: true,
-        }),
-      ),
+      this.dispatchStandardEvent('input', {
+        bubbles: true,
+        composed: true,
+      }),
     )
   }
 

--- a/libs/core/src/components/details/details.component.ts
+++ b/libs/core/src/components/details/details.component.ts
@@ -106,13 +106,11 @@ export class GdsDetails extends withSizeXProps(
   }
 
   #dispatchStateEvent = (): void => {
-    this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        bubbles: true,
-        composed: true,
-        detail: this.open,
-      }),
-    )
+    this.dispatchCustomEvent('gds-ui-state', {
+      bubbles: true,
+      composed: true,
+      detail: this.open,
+    })
   }
 
   render() {

--- a/libs/core/src/components/dialog/dialog.component.ts
+++ b/libs/core/src/components/dialog/dialog.component.ts
@@ -202,36 +202,23 @@ export class GdsDialog extends withSizeXProps(withSizeYProps(GdsElement)) {
   }
 
   #dispatchCloseEvent = (reason?: string) => {
-    this.dispatchEvent(
-      new CustomEvent('gds-close', {
-        detail: reason,
-        bubbles: false,
-        composed: false,
-      }),
-    )
+    this.dispatchCustomEvent('gds-close', {
+      detail: reason,
+    })
     return this.#dispatchUiStateEvent(reason)
   }
 
   #dispatchShowEvent = (reason?: string) => {
-    this.dispatchEvent(
-      new CustomEvent('gds-show', {
-        detail: reason,
-        bubbles: false,
-        composed: false,
-      }),
-    )
+    this.dispatchCustomEvent('gds-show', {
+      detail: reason,
+    })
     return this.#dispatchUiStateEvent(reason)
   }
 
   #dispatchUiStateEvent = (reason?: string) => {
-    return this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        detail: { reason, open: this.open },
-        bubbles: false,
-        composed: false,
-        cancelable: true,
-      }),
-    )
+    return this.dispatchCustomEvent('gds-ui-state', {
+      detail: { reason, open: this.open },
+    })
   }
 
   #handleTriggerSlotChange() {

--- a/libs/core/src/components/dropdown/dropdown.component.ts
+++ b/libs/core/src/components/dropdown/dropdown.component.ts
@@ -516,14 +516,11 @@ export class GdsDropdown<ValueT = any>
   }
 
   #dispatchUISateEvent = (toState: boolean, reason: UIStateChangeReason) =>
-    this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        detail: { reason, open: toState },
-        bubbles: false,
-        composed: false,
-        cancelable: true,
-      }),
-    )
+    this.dispatchCustomEvent('gds-ui-state', {
+      detail: { reason, open: toState },
+      bubbles: false,
+      composed: false,
+    })
 
   #handlePopoverStateChange = (e: CustomEvent) => {
     if (this.#dispatchUISateEvent(e.detail.open, e.detail.reason)) {
@@ -543,12 +540,9 @@ export class GdsDropdown<ValueT = any>
     e.stopPropagation()
 
     // Emit cancellable filter input event. If cancelled, consumer is expreced to handle filtering and update the options list.
-    const wasCancelled = !this.dispatchEvent(
-      new CustomEvent('gds-filter-input', {
-        detail: { value: (e.currentTarget as HTMLInputElement).value },
-        cancelable: true,
-      }),
-    )
+    const wasCancelled = !this.dispatchCustomEvent('gds-filter-input', {
+      detail: { value: (e.currentTarget as HTMLInputElement).value },
+    })
 
     if (wasCancelled) return
 
@@ -618,24 +612,20 @@ export class GdsDropdown<ValueT = any>
 
   #dispatchInputEvent = () => {
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new Event('input', {
-          bubbles: true,
-          composed: true,
-        }),
-      ),
+      this.dispatchStandardEvent('input', {
+        bubbles: true,
+        composed: true,
+      }),
     )
   }
 
   #dispatchChangeEvent = () => {
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new CustomEvent('change', {
-          detail: { value: this.value },
-          bubbles: true,
-          composed: true,
-        }),
-      ),
+      this.dispatchCustomEvent('change', {
+        detail: { value: this.value },
+        bubbles: true,
+        composed: true,
+      }),
     )
   }
 

--- a/libs/core/src/components/filter-chips/filter-chips.component.ts
+++ b/libs/core/src/components/filter-chips/filter-chips.component.ts
@@ -116,13 +116,11 @@ export class GdsFilterChips<ValueT = any> extends GdsFormControlElement<
         this.value = clickedChip.value
       }
 
-      this.dispatchEvent(
-        new CustomEvent('change', {
-          detail: { clickedChip, value: this.value },
-          bubbles: true,
-          composed: true,
-        }),
-      )
+      this.dispatchCustomEvent('change', {
+        detail: { clickedChip, value: this.value },
+        bubbles: true,
+        composed: true,
+      })
     }
   }
 

--- a/libs/core/src/components/form/form-control.ts
+++ b/libs/core/src/components/form/form-control.ts
@@ -197,16 +197,13 @@ export abstract class GdsFormControlElement<ValueT = any>
 
     if (oldValue !== this.invalid) {
       this.requestUpdate('invalid', oldValue)
-      this.dispatchEvent(
-        new CustomEvent('gds-validity-state', {
-          bubbles: true,
-          composed: true,
-          detail: {
-            valid: this.validity.valid,
-            message: this.validationMessage,
-          },
-        }),
-      )
+      this.dispatchCustomEvent('gds-validity-state', {
+        detail: {
+          valid: this.validity.valid,
+          message: this.validationMessage,
+        },
+        composed: true,
+      })
     }
 
     return this.#internals.checkValidity()

--- a/libs/core/src/components/input/input.component.ts
+++ b/libs/core/src/components/input/input.component.ts
@@ -242,12 +242,10 @@ class Input extends GdsFormControlElement<string> {
   #handleOnChange = (e: Event) => {
     const element = e.target as HTMLInputElement
     this.value = element.value
-    this.dispatchEvent(
-      new Event('change', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
+    this.dispatchStandardEvent('change', {
+      bubbles: true,
+      composed: true,
+    })
   }
 
   #handleFieldClick = () => {
@@ -256,18 +254,14 @@ class Input extends GdsFormControlElement<string> {
 
   #handleClearBtnClick = () => {
     this.value = ''
-    this.dispatchEvent(
-      new Event('gds-input-cleared', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
-    this.dispatchEvent(
-      new Event('input', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
+    this.dispatchCustomEvent('gds-input-cleared', {
+      bubbles: true,
+      composed: true,
+    })
+    this.dispatchStandardEvent('input', {
+      bubbles: true,
+      composed: true,
+    })
   }
 
   #renderFieldContents() {

--- a/libs/core/src/components/popover/popover.component.ts
+++ b/libs/core/src/components/popover/popover.component.ts
@@ -353,14 +353,12 @@ export class GdsPopover extends GdsElement {
 
   #dispatchUiStateEvent = (reason: UIStateChangeReason) => {
     const toState = reason === 'show' ? true : false
-    return this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        detail: { open: toState, reason },
-        bubbles: false,
-        composed: false,
-        cancelable: true,
-      }),
-    )
+    return this.dispatchCustomEvent('gds-ui-state', {
+      detail: { open: toState, reason },
+      bubbles: false,
+      composed: false,
+      cancelable: true,
+    })
   }
 
   #handleCloseButton = (e: MouseEvent) => {
@@ -368,11 +366,6 @@ export class GdsPopover extends GdsElement {
     e.preventDefault()
     if (this.#dispatchUiStateEvent('close')) {
       this.open = false
-
-      // The timeout here is to work around a strange default behaviour in VoiceOver on iOS, where when you close
-      // a dialog, the focus gets moved to the element that is visually closest to where the focus was in the
-      // dialog (close button in this case.)
-      // The timeout waits for VoiceOver to do its thing, then moves focus back to the trigger.
       setTimeout(() => this._trigger?.focus(), 250)
     }
   }

--- a/libs/core/src/components/radio/radio-group/radio-group.component.ts
+++ b/libs/core/src/components/radio/radio-group/radio-group.component.ts
@@ -144,20 +144,16 @@ class RadioGroup extends GdsFormControlElement<string> {
 
   #dispatchChangeEvents() {
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new Event('change', {
-          composed: true,
-          bubbles: true,
-        }),
-      ),
+      this.dispatchStandardEvent('change', {
+        composed: true,
+        bubbles: true,
+      }),
     )
     this.updateComplete.then(() =>
-      this.dispatchEvent(
-        new Event('input', {
-          bubbles: true,
-          composed: true,
-        }),
-      ),
+      this.dispatchStandardEvent('input', {
+        bubbles: true,
+        composed: true,
+      }),
     )
   }
 

--- a/libs/core/src/components/radio/radio.component.ts
+++ b/libs/core/src/components/radio/radio.component.ts
@@ -96,7 +96,7 @@ export class GdsRadio extends GdsElement {
 
     this.checked = true
     this.focus()
-    this.dispatchEvent(new Event('input', { bubbles: true }))
+    this.dispatchStandardEvent('input', { bubbles: true })
   }
 
   #handleKeyDown = (e: KeyboardEvent) => {
@@ -105,7 +105,7 @@ export class GdsRadio extends GdsElement {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       this.checked = true
-      this.dispatchEvent(new Event('input', { bubbles: true }))
+      this.dispatchStandardEvent('input', { bubbles: true })
     }
   }
 

--- a/libs/core/src/components/segmented-control/segmented-control.component.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.component.ts
@@ -223,13 +223,11 @@ export class GdsSegmentedControl<ValueT = any> extends withLayoutChildProps(
 
       this.#updateIndicator()
 
-      this.dispatchEvent(
-        new CustomEvent('change', {
-          detail: { segment: selectedSegment },
-          bubbles: true,
-          composed: true,
-        }),
-      )
+      this.dispatchCustomEvent('change', {
+        detail: { segment: selectedSegment },
+        bubbles: true,
+        composed: true,
+      })
     }
   }
 

--- a/libs/core/src/components/select/select.component.ts
+++ b/libs/core/src/components/select/select.component.ts
@@ -235,21 +235,16 @@ class Select<ValueT = string> extends GdsFormControlElement<ValueT | ValueT[]> {
     this.#setValueFromSelectElement()
 
     requestAnimationFrame(() => {
-      this.dispatchEvent(
-        new CustomEvent('input', {
-          detail: { value: this.value },
-          bubbles: true,
-          composed: true,
-        }),
-      )
-
-      this.dispatchEvent(
-        new CustomEvent('change', {
-          detail: { value: this.value },
-          bubbles: true,
-          composed: true,
-        }),
-      )
+      this.dispatchCustomEvent('input', {
+        detail: { value: this.value },
+        bubbles: true,
+        composed: true,
+      })
+      this.dispatchCustomEvent('change', {
+        detail: { value: this.value },
+        bubbles: true,
+        composed: true,
+      })
     })
   }
 

--- a/libs/core/src/components/spinner/spinner.component.ts
+++ b/libs/core/src/components/spinner/spinner.component.ts
@@ -110,7 +110,7 @@ export class GdsSpinner extends withMarginProps(
     this.setAttribute('role', 'status')
     this.setAttribute('aria-live', 'polite')
     this._isAnimating = true
-    this.dispatchEvent(new CustomEvent('gds-spinner-connected'))
+    this.dispatchCustomEvent('gds-spinner-connected')
   }
 
   /**

--- a/libs/core/src/components/textarea/textarea.component.ts
+++ b/libs/core/src/components/textarea/textarea.component.ts
@@ -292,12 +292,10 @@ class Textarea extends GdsFormControlElement<string> {
   #handleOnChange = (e: Event) => {
     const element = e.target as HTMLInputElement
     this.value = element.value
-    this.dispatchEvent(
-      new Event('change', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
+    this.dispatchStandardEvent('change', {
+      bubbles: true,
+      composed: true,
+    })
   }
 
   #handleOnPaste = (e: ClipboardEvent) => {
@@ -371,19 +369,14 @@ class Textarea extends GdsFormControlElement<string> {
       }
     })
 
-    this.dispatchEvent(
-      new Event('gds-input-cleared', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
-
-    this.dispatchEvent(
-      new Event('input', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
+    this.dispatchCustomEvent('gds-input-cleared', {
+      bubbles: true,
+      composed: true,
+    })
+    this.dispatchStandardEvent('input', {
+      bubbles: true,
+      composed: true,
+    })
   }
 
   @watch('rows')

--- a/libs/core/src/components/theme/theme.component.ts
+++ b/libs/core/src/components/theme/theme.component.ts
@@ -71,19 +71,15 @@ export class GdsTheme extends GdsElement {
       )
     }
 
-    this.dispatchEvent(
-      new CustomEvent('gds-color-scheme-changed', {
-        detail: { colorScheme: this.colorScheme },
-      }),
-    )
+    this.dispatchCustomEvent('gds-color-scheme-changed', {
+      detail: { colorScheme: this.colorScheme },
+    })
   }
 
   @watch('designVersion')
   private _onDesignVersionChange() {
-    this.dispatchEvent(
-      new CustomEvent('gds-design-version-changed', {
-        detail: { designVersion: this.designVersion },
-      }),
-    )
+    this.dispatchCustomEvent('gds-design-version-changed', {
+      detail: { designVersion: this.designVersion },
+    })
   }
 }

--- a/libs/core/src/gds-element.test.ts
+++ b/libs/core/src/gds-element.test.ts
@@ -1,0 +1,94 @@
+import { expect } from '@esm-bundle/chai'
+import { fixture, html as testingHtml } from '@open-wc/testing'
+import sinon from 'sinon'
+
+import { GdsElement } from './gds-element'
+import { gdsCustomElement, htmlTemplateTagFactory } from './scoping'
+
+const html = htmlTemplateTagFactory(testingHtml)
+
+@gdsCustomElement('gds-test-component')
+class TestComponent extends GdsElement {}
+
+TestComponent.define()
+
+describe('GdsElement', () => {
+  it('should define the custom element', () => {
+    expect(TestComponent.isDefined).to.be.true
+  })
+
+  it('should set gdsElementName attribute on connectedCallback', async () => {
+    const el = await fixture<TestComponent>(html`
+      <gds-test-component></gds-test-component>
+    `)
+    expect(el.getAttribute('gds-element')).to.equal('gds-test-component')
+    el.parentNode!.removeChild(el)
+  })
+
+  it('should dispatch gds-element-disconnected event on disconnectedCallback', async () => {
+    const el = await fixture<TestComponent>(html`
+      <gds-test-component></gds-test-component>
+    `)
+    const spy = sinon.spy()
+    el.addEventListener('gds-element-disconnected', spy)
+    el.parentNode!.removeChild(el)
+    expect(spy.calledOnce).to.be.true
+  })
+
+  it('should have a default style expression base selector', () => {
+    expect(TestComponent.styleExpressionBaseSelector).to.equal(':host')
+  })
+
+  it('should dispatch standard events in both default and pascal case versions', async () => {
+    const el = await fixture<TestComponent>(html`
+      <gds-test-component></gds-test-component>
+    `)
+    const spy = sinon.spy()
+    const spyPascal = sinon.spy()
+
+    el.addEventListener('test-event', spy)
+    el.addEventListener('TestEvent', spyPascal)
+
+    el.dispatchStandardEvent('test-event')
+
+    expect(spy.calledOnce).to.be.true
+    expect(spyPascal.calledOnce).to.be.true
+    expect(spy.firstCall.args[0].type).to.equal('test-event')
+    expect(spyPascal.firstCall.args[0].type).to.equal('TestEvent')
+  })
+
+  it('should dispatch custom events in both default and pascal case versions', async () => {
+    const el = await fixture<TestComponent>(html`
+      <gds-test-component></gds-test-component>
+    `)
+    const spy = sinon.spy()
+    const spyPascal = sinon.spy()
+    el.addEventListener('custom-event', spy)
+    el.addEventListener('CustomEvent', spyPascal)
+    el.dispatchCustomEvent('custom-event', { detail: { foo: 'bar' } })
+    expect(spy.calledOnce).to.be.true
+    expect(spyPascal.calledOnce).to.be.true
+    expect(spy.firstCall.args[0].type).to.equal('custom-event')
+    expect(spyPascal.firstCall.args[0].type).to.equal('CustomEvent')
+    expect(spy.firstCall.args[0].detail).to.deep.equal({ foo: 'bar' })
+    expect(spyPascal.firstCall.args[0].detail).to.deep.equal({ foo: 'bar' })
+  })
+
+  it('should dispatch events that are cancelable', async () => {
+    const el = await fixture<TestComponent>(html`
+      <gds-test-component></gds-test-component>
+    `)
+    const spy = sinon.spy()
+    el.addEventListener('cancelable-event', (event) => {
+      event.preventDefault()
+      spy()
+    })
+    const event = new CustomEvent('cancelable-event', {
+      bubbles: true,
+      cancelable: true,
+    })
+    el.dispatchEvent(event)
+    expect(spy.calledOnce).to.be.true
+    expect(event.defaultPrevented).to.be.true
+  })
+})

--- a/libs/core/src/gds-element.ts
+++ b/libs/core/src/gds-element.ts
@@ -7,6 +7,13 @@ import { DynamicStylesController } from './utils/controllers/dynamic-styles-cont
 // More info: https://lit.dev/Components/decorators/#decorator-versions
 import 'reflect-metadata'
 
+function toPascalCase(str: string): string {
+  return str
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')
+}
+
 /**
  * Base class for Green Core elements.
  * This class sets up the base functionality that all Green Core elements share.
@@ -74,5 +81,47 @@ export class GdsElement extends LitElement {
         composed: false,
       }),
     )
+  }
+
+  /**
+   * Dispatches a standard event with the given name and options.
+   * A pascal cased version of the event name is also dispatched for compatibility.
+   */
+  dispatchStandardEvent(name: string, options?: EventInit): boolean {
+    const computedOptions = {
+      bubbles: true,
+      composed: false,
+      cancelable: true,
+      ...options,
+    }
+
+    // Dispatch both the original event name and a pascal cased version
+    // to maintain compatibility with both naming conventions, and consolidate
+    // the results to capture any cancellation.
+    return [
+      this.dispatchEvent(new Event(name, computedOptions)),
+      this.dispatchEvent(new Event(toPascalCase(name), computedOptions)),
+    ].every((event) => event !== false)
+  }
+
+  /**
+   * Dispatches a custom event with the given name and options.
+   * A pascal cased version of the event name is also dispatched for compatibility.
+   */
+  dispatchCustomEvent<T>(
+    name: string,
+    options: CustomEventInit<T> = {},
+  ): boolean {
+    const computedOptions = {
+      bubbles: true,
+      composed: false,
+      cancelable: true,
+      ...options,
+    }
+
+    return [
+      this.dispatchEvent(new CustomEvent(name, computedOptions)),
+      this.dispatchEvent(new CustomEvent(toPascalCase(name), computedOptions)),
+    ].every((event) => event !== false)
   }
 }

--- a/libs/core/src/primitives/form-control-header/form-control-header.component.ts
+++ b/libs/core/src/primitives/form-control-header/form-control-header.component.ts
@@ -87,13 +87,11 @@ export class GdsFormControlHeader extends GdsElement {
         : '0',
     )
 
-    this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        bubbles: true,
-        composed: true,
-        detail: this.showExtendedSupportingText,
-      }),
-    )
+    this.dispatchCustomEvent('gds-ui-state', {
+      bubbles: true,
+      composed: true,
+      detail: this.showExtendedSupportingText,
+    })
   }
 
   #renderExtSupTxt() {

--- a/libs/core/src/primitives/listbox/listbox.component.ts
+++ b/libs/core/src/primitives/listbox/listbox.component.ts
@@ -152,11 +152,9 @@ export class GdsListbox
 
     ;(this as any).ariaActiveDescendantElement = option
 
-    this.dispatchEvent(
-      new CustomEvent('change', {
-        bubbles: false,
-        composed: false,
-      }),
-    )
+    this.dispatchCustomEvent('change', {
+      bubbles: false,
+      composed: false,
+    })
   }
 }

--- a/libs/core/src/primitives/listbox/option.component.ts
+++ b/libs/core/src/primitives/listbox/option.component.ts
@@ -139,14 +139,12 @@ export class GdsOption extends Focusable(GdsElement) {
 
   #emitSelect(e: MouseEvent | KeyboardEvent) {
     e.stopPropagation()
-    this.dispatchEvent(
-      new CustomEvent('gds-select', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          value: this.value,
-        },
-      }),
-    )
+    this.dispatchCustomEvent('gds-select', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        value: this.value,
+      },
+    })
   }
 }

--- a/libs/core/src/primitives/menu/menu-item.component.ts
+++ b/libs/core/src/primitives/menu/menu-item.component.ts
@@ -28,12 +28,10 @@ export class GdsMenuItem extends Focusable(GdsElement) {
   }
 
   #handleOnClick = () => {
-    this.dispatchEvent(
-      new CustomEvent('gds-menu-item-click', {
-        bubbles: true,
-        composed: true,
-      }),
-    )
+    this.dispatchCustomEvent('gds-menu-item-click', {
+      bubbles: true,
+      composed: true,
+    })
   }
 
   render() {

--- a/libs/core/src/storybook-docs/contributing/coding-guidelines.mdx
+++ b/libs/core/src/storybook-docs/contributing/coding-guidelines.mdx
@@ -16,7 +16,7 @@ Names should be prefixed with `Gds` to indicate that they are part of a Green Co
 
 ### Class names
 
-Class names should be written in PascalCase, and should reflect the name of the component or feature that the class represents. For example, a class representing a button component should be named `GdsButton`. 
+Class names should be written in PascalCase, and should reflect the name of the component or feature that the class represents. For example, a class representing a button component should be named `GdsButton`.
 
 ### Custom element names
 
@@ -25,6 +25,12 @@ Custom element names should be written in kebab-case, and should reflect the nam
 ## Always extend GdsElement
 
 All components in Green Core should extend the `GdsElement` base class. Among some other minor things, this class adds the standard `gds-element` attribute to all components. Check the source code for more details.
+
+## Events
+
+Aim to use standard events when applicable, for example, a form control should dispatch a standard `input` event when the value is updated. In other cases, where you need to use a custom event, name it `gds-[custom-event-name]`.
+
+The GdsElement base class has event dispatch helper methods that should be used for all event dispatching. The helpers will automatically emit a CamelCased version of the event, so that it can be used in React and other frameworks that use CamelCase for event names. For example, if you dispatch a `gds-ui-state` event, the helper will also emit an `GdsUiState` event, which can be used as `onGdsUiState` in React.
 
 ## \# for private properties
 

--- a/libs/core/src/storybook-docs/guides/react.mdx
+++ b/libs/core/src/storybook-docs/guides/react.mdx
@@ -26,6 +26,10 @@ These imports are tree-shakable and the underlying web components will be define
 
 Then, you can use the component in your JSX template as shown above.
 
+### Events
+
+All events in Green Core has a corresponding CamelCased version that you can use in React. For example, if you see an event called `gds-ui-state`, you can use `onGdsUiState` in react.
+
 ### Web component quirks with React
 
 There are a few quirks to be aware of when using web components with React:


### PR DESCRIPTION
This PR adds event dispatch helpers to the `GdsElement` base class. These helpers standardizes how we dispatch events, and automatically emits a pascal case version of the events for better React compatibility.