### PR TITLE
Focus handling: Fix issues with programmatic focus shifting

### DIFF
--- a/.changeset/fifty-candles-smoke.md
+++ b/.changeset/fifty-candles-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Focus handling:** Fix issues with programmatic focus shifting with some form controls

--- a/libs/core/src/components/button/button.component.ts
+++ b/libs/core/src/components/button/button.component.ts
@@ -117,6 +117,10 @@ class Button extends GdsFormControlElement<any> {
     TransitionalStyles.instance.apply(this, 'gds-button')
   }
 
+  focus(options?: FocusOptions): void {
+    this._getValidityAnchor()?.focus(options)
+  }
+
   get #isLink() {
     return this.href.length > 0
   }

--- a/libs/core/src/components/datepicker/datepicker.component.ts
+++ b/libs/core/src/components/datepicker/datepicker.component.ts
@@ -245,6 +245,10 @@ class Datepicker extends GdsFormControlElement<Date> {
     TransitionalStyles.instance.apply(this, 'gds-datepicker')
   }
 
+  focus(options?: FocusOptions): void {
+    this._getValidityAnchor()?.focus(options)
+  }
+
   render() {
     return html`
       ${when(

--- a/libs/core/src/components/filter-chips/filter-chips.component.ts
+++ b/libs/core/src/components/filter-chips/filter-chips.component.ts
@@ -95,8 +95,12 @@ export class GdsFilterChips<ValueT = any> extends GdsFormControlElement<
     </div>`
   }
 
+  focus(options?: FocusOptions): void {
+    this.chips[0]?.focus(options)
+  }
+
   protected _getValidityAnchor(): HTMLElement {
-    return this
+    return this.shadowRoot?.querySelector('div') as HTMLElement
   }
 
   #handleChipClick = (event: Event) => {

--- a/libs/core/src/components/form-summary/summary.stories.ts
+++ b/libs/core/src/components/form-summary/summary.stories.ts
@@ -9,6 +9,8 @@ import '../datepicker/index.ts'
 import '../dropdown/index.ts'
 import '../input/index.ts'
 import '../icon/icons/rocket.ts'
+import '../checkbox/index.ts'
+import '../radio/index.ts'
 
 /**
  * [Source code](https://github.com/seb-oss/green/tree/main/libs/core/src/components/form-summary)
@@ -59,6 +61,42 @@ export const Usage: Story = {
         border-color="primary"
       >
         <gds-text tag="h2">Launch control</gds-text>
+        <gds-checkbox-group
+          direction="row"
+          label="Mission type"
+          .validator=${{
+            validate: (el: any) => {
+              if (el.value.length === 0)
+                return [
+                  { ...el.validity, valid: false, customError: true },
+                  'At least one mission type is required',
+                ]
+            },
+          }}
+        >
+          <gds-checkbox value="exploration" label="Exploration"></gds-checkbox>
+          <gds-checkbox value="research" label="Research"></gds-checkbox>
+          <gds-checkbox value="rescue" label="Rescue"></gds-checkbox>
+          <gds-checkbox value="other" label="Other"></gds-checkbox>
+        </gds-checkbox-group>
+        <gds-radio-group
+          direction="row"
+          label="Rocket type"
+          .validator=${{
+            validate: (el: any) => {
+              if (el.value === undefined)
+                return [
+                  { ...el.validity, valid: false, customError: true },
+                  'A rocket type is required',
+                ]
+            },
+          }}
+        >
+          <gds-radio value="falcon" label="Falcon"></gds-radio>
+          <gds-radio value="starship" label="Starship"></gds-radio>
+          <gds-radio value="saturn" label="Saturn"></gds-radio>
+          <gds-radio value="other" label="Other"></gds-radio>
+        </gds-radio-group>
         <gds-dropdown
           label="Astronaut"
           .validator=${{

--- a/libs/core/src/components/form/form-control.ts
+++ b/libs/core/src/components/form/form-control.ts
@@ -233,13 +233,10 @@ export abstract class GdsFormControlElement<ValueT = any>
     if (!this.validity.valid) e.preventDefault()
   }
 
-  // TODO: This needs to be handled on a component by component basis, since it's not always the validity anchor that should be the focus reciever.
-  focus(options?: FocusOptions | undefined): void {
-    this._getValidityAnchor().focus(options)
-  }
-
   /**
-   * This should return a reference to the HTML element that will recive the focus when the form control is invalid.
+   * This should return a reference to the HTML element that the browser will refer to when the form control is invalid.
+   * The reference is used when setting the validity state in ElementInternals.
+   * For reference: https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setValidity#anchor
    */
   protected abstract _getValidityAnchor(): HTMLElement
 }

--- a/libs/core/src/components/input/input.component.ts
+++ b/libs/core/src/components/input/input.component.ts
@@ -187,6 +187,10 @@ class Input extends GdsFormControlElement<string> {
     this.value = ''
   }
 
+  focus(options?: FocusOptions): void {
+    this._getValidityAnchor()?.focus(options)
+  }
+
   render() {
     return html`
       ${when(

--- a/libs/core/src/components/radio/radio-group/radio-group.component.ts
+++ b/libs/core/src/components/radio/radio-group/radio-group.component.ts
@@ -84,6 +84,10 @@ class RadioGroup extends GdsFormControlElement<string> {
     this.removeEventListener('invalid', this._syncRadioStates)
   }
 
+  focus(options?: FocusOptions): void {
+    this._getValidityAnchor()?.focus(options)
+  }
+
   protected _getValidityAnchor(): HTMLElement {
     return this._contentElement
   }

--- a/libs/core/src/components/select/select.component.ts
+++ b/libs/core/src/components/select/select.component.ts
@@ -110,6 +110,10 @@ class Select<ValueT = string> extends GdsFormControlElement<ValueT | ValueT[]> {
     })
   }
 
+  focus(options?: FocusOptions): void {
+    this._getValidityAnchor()?.focus(options)
+  }
+
   render() {
     const CLASSES = {
       multiple: this.multiple,

--- a/libs/core/src/components/textarea/textarea.component.ts
+++ b/libs/core/src/components/textarea/textarea.component.ts
@@ -180,6 +180,10 @@ class Textarea extends GdsFormControlElement<string> {
     return this.shadowRoot?.querySelector('#field')
   }
 
+  focus(options?: FocusOptions): void {
+    this._getValidityAnchor()?.focus(options)
+  }
+
   @resizeObserver()
   private _handleResize() {
     if (!this.fieldBase) return


### PR DESCRIPTION
This PR removes the base implementation of `focus()` in `GdsFormControl`, since it otherwise blocks access to the native `focus()` method from child classes.

This prevented programmatic focus from working correctly with some components, such as Checkbox.

Each form control now needs to implement this locally if required.