### PR TITLE
fix: Angular small date-input error border bug

### DIFF
--- a/.changeset/bright-lizards-rush.md
+++ b/.changeset/bright-lizards-rush.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+Changed height of nggv-dateinput wrapper to match nggv-input

--- a/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.scss
+++ b/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.scss
@@ -208,8 +208,8 @@
     }
 
     .field-wrap {
-      height: calc(2rem + 2px);
-      min-height: calc(2rem + 2px);
+      height: calc(2rem + 3px);
+      min-height: calc(2rem + 3px);
     }
     .field-wrap .nggv-field-date {
       padding: 0.38rem 0.5rem;


### PR DESCRIPTION
## Background
Currently, when setting the Angular `nggv-dateinput` `size="small"` and at the same time showing an error, the border gets slightly cut off for the input, while the button shows the full border. 
<img width="571" height="79" alt="image" src="https://github.com/user-attachments/assets/e620b069-84ff-45f6-b045-53c4ff5d8253" />

## Fix
- Changed `height` and `min-height` from `calc(2rem + 2px)` to `calc(2rem + 3px)` of `.field-wrap` in `nggv-dateinput`. 

## Context
An inconsistency was found while searching for the cause of this bug, as the date-picker input wrapper is one pixel smaller than a regular input wrapper when both are set to `size="small"`, as seen below. Both images taken from the Storybook.

**nggv-dateinput**
<img width="1229" height="106" alt="image" src="https://github.com/user-attachments/assets/0113e778-231f-406b-b072-2f893204d1b5" />

**nggv-input**
<img width="1233" height="114" alt="image" src="https://github.com/user-attachments/assets/824544d6-01c7-4cad-8db2-48a3d0241159" />

To make sure that the inputs are consistent in height, a pixel was added to both `height` and `min-height` of of `.field-wrap` in `nggv-dateinput`, which both makes the two components the same height and the error border shown correctly.
<img width="569" height="90" alt="image" src="https://github.com/user-attachments/assets/cf5680b4-93d2-4699-ba24-fa175fb1edef" />

