### PR TITLE
listWidth property to fold out component - danger button to dialog component

### DIFF
--- a/.changeset/large-mice-travel.md
+++ b/.changeset/large-mice-travel.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+listWidth property to fold out component - added danger button to dialog component

--- a/.changeset/large-mice-travel.md
+++ b/.changeset/large-mice-travel.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-angular': patch
 ---
 
-listWidth property to fold out component - added danger button to dialog component
+**V-Angular:** listWidth property to fold out component - added danger button to dialog component

--- a/libs/angular/src/v-angular/i18n/i18n.json
+++ b/libs/angular/src/v-angular/i18n/i18n.json
@@ -5,6 +5,7 @@
   "label.defaultlabel": "Label",
   "label.maxlength": "characters left",
   "label.optional": "Optional",
+  "button_delete": "Delete",
   "button_cancel": "Cancel",
   "button_apply": "Apply",
   "button_save": "Save",

--- a/libs/angular/src/v-angular/modal/dialog/dialog.component.html
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.component.html
@@ -27,7 +27,7 @@
       </section>
       <footer class="modal-dialog__actions">
         <button
-          class="danger"
+          class="danger-confirm"
           type="reset"
           [attr.data-thook]="'dialog-' + (_buttons?.negative || 'negative')"
           (click)="onAction($event, 'negative')"
@@ -45,6 +45,16 @@
           *ngIf="_buttons && _buttons.neutral"
         >
           {{ t(_buttons.neutral) }}
+        </button>
+        <button
+          class="danger"
+          type="submit"
+          [attr.data-thook]="'dialog-' + (_buttons?.danger || 'danger')"
+          (click)="onAction($event, 'danger')"
+          (keydown.enter)="onAction($event, 'danger')"
+          *ngIf="_buttons && _buttons.danger"
+        >
+          {{ t(_buttons.danger) }}
         </button>
         <button
           class="submit"

--- a/libs/angular/src/v-angular/modal/dialog/dialog.component.scss
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.component.scss
@@ -71,8 +71,11 @@
     .secondary {
       @include button.secondary;
     }
-    .danger {
+    .danger-confirm {
       @include button.danger-color;
+    }
+    .danger {
+      @include button.danger-bg;
     }
   }
 }

--- a/libs/angular/src/v-angular/modal/dialog/dialog.component.ts
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.component.ts
@@ -94,6 +94,7 @@ export class NggvDialogComponent implements OnInit, OnDestroy {
   @Output() nggvPositiveEvent = new EventEmitter<DialogEvent>()
   @Output() nggvNeutralEvent = new EventEmitter<DialogEvent>()
   @Output() nggvNegativeEvent = new EventEmitter<DialogEvent>()
+  @Output() nggvDangerEvent = new EventEmitter<DialogEvent>()
 
   protected _previous: HTMLElement | undefined
   protected _firstFocusable: HTMLElement | undefined
@@ -136,6 +137,9 @@ export class NggvDialogComponent implements OnInit, OnDestroy {
         break
       case 'negative':
         this.nggvNegativeEvent.emit(emitEvent)
+        break
+      case 'danger':
+        this.nggvDangerEvent.emit(emitEvent)
         break
       // case 'close' is handled by if-statement below with call to this.close()
     }

--- a/libs/angular/src/v-angular/modal/dialog/dialog.stories.ts
+++ b/libs/angular/src/v-angular/modal/dialog/dialog.stories.ts
@@ -1,9 +1,6 @@
-import { CommonModule } from '@angular/common'
-
-import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
-
 import '../modal.globals'
 
+import { CommonModule } from '@angular/common'
 import { CUSTOM_ELEMENTS_SCHEMA, importProvidersFrom } from '@angular/core'
 import {
   applicationConfig,
@@ -12,6 +9,7 @@ import {
   StoryFn,
 } from '@storybook/angular'
 
+import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 import { DropdownUtils } from '../../core'
 import { NggvDropdownModule } from '../../dropdown/dropdown.module'
 import { NggvI18nModule } from '../../i18n/i18n.module'
@@ -94,6 +92,7 @@ Primary.args = {
     negative: 'button_cancel',
     neutral: 'button_apply',
     positive: 'button_save',
+    danger: 'button_delete',
   },
   content:
     'You can supply the content seen here either through the <code>[content]="string"</code> property or</br>by passing children between the opening and closing tags <code>&lt;c-dialog&gt; ...children &lt;/c-dialog&gt;</code>',

--- a/libs/angular/src/v-angular/modal/fold-out/fold-out.component.html
+++ b/libs/angular/src/v-angular/modal/fold-out/fold-out.component.html
@@ -9,11 +9,16 @@
   >
     <ng-container *ngTemplateOutlet="text ? withText : default"> </ng-container>
   </button>
-
   <div
     #childrenContainer
     class="nggv-fold-out__popover"
-    [ngClass]="{ 'flex-right': alignOptions === 'right' }"
+    [ngClass]="{
+      'flex-right': alignOptions === 'right',
+      'list-width-fit-content': listWidth === 'fit-content',
+      'list-width-max-content': listWidth === 'max-content',
+      'list-width-min-content': listWidth === 'min-content',
+      'list-width-auto': listWidth === 'auto',
+    }"
     [class.nggv-fold-out__popover-expanded]="shown"
     (click)="toggleVisibility()"
   >

--- a/libs/angular/src/v-angular/modal/fold-out/fold-out.component.scss
+++ b/libs/angular/src/v-angular/modal/fold-out/fold-out.component.scss
@@ -24,6 +24,21 @@
     right: 0;
   }
 
+  .list-width {
+    &-fit-content {
+      width: fit-content;
+    }
+    &-max-content {
+      width: max-content;
+    }
+    &-min-content {
+      width: min-content;
+    }
+    &-auto {
+      width: auto;
+    }
+  }
+
   .fold-out-button {
     @include button.reset();
     @include button.base();
@@ -44,7 +59,6 @@
 
   .nggv-fold-out__popover {
     @include card.card();
-    width: fit-content;
     display: none;
     padding: 0;
 

--- a/libs/angular/src/v-angular/modal/fold-out/fold-out.component.ts
+++ b/libs/angular/src/v-angular/modal/fold-out/fold-out.component.ts
@@ -11,7 +11,6 @@ import {
   Output,
   ViewChild,
 } from '@angular/core'
-
 import { fromEvent, Subscription } from 'rxjs'
 import { filter, takeWhile } from 'rxjs/operators'
 
@@ -36,6 +35,9 @@ export class NggvFoldOutComponent implements OnDestroy, AfterViewInit {
   @Input() text?: string
   /** Aria label for the fold-out button */
   @Input() ariaLabel?: string
+  /** Sets the width property of the list. Default = fit-content */
+  @Input() listWidth: 'fit-content' | 'max-content' | 'min-content' | 'auto' =
+    'fit-content'
   /** Emits when the children container collapses, for components with change detection strategy "OnPush" */
   @Output() actionEmitter = new EventEmitter<void>()
 

--- a/libs/angular/src/v-angular/modal/fold-out/fold-out.stories.ts
+++ b/libs/angular/src/v-angular/modal/fold-out/fold-out.stories.ts
@@ -25,6 +25,18 @@ export default {
         type: 'inline-radio',
       },
     },
+    listWidth: {
+      options: ['fit-content', 'max-content', 'min-content', 'auto'],
+      control: {
+        type: 'select',
+        labels: {
+          'fit-content': 'fit-content',
+          'max-content': 'max-content',
+          'min-content': 'min-content',
+          auto: 'auto',
+        },
+      },
+    },
   },
 } as Meta
 
@@ -33,7 +45,7 @@ const Template: StoryFn<NggvFoldOutComponent> = (args: any) => {
   return {
     template: /* html */ `
     <div class="story-wrapper">
-      <nggv-fold-out [alignOptions]="alignOptions">
+      <nggv-fold-out [alignOptions]="alignOptions" [listWidth]="listWidth">
         <div nggvOption (click)="lastClicked = 'View details'">View details</div>
         <div nggvOption (click)="lastClicked = 'Sign payment'">Sign payment</div>
         <div nggvOption class="delete-option" (click)="lastClicked = 'Delete'">Delete</div>
@@ -50,7 +62,7 @@ const TemplateAlt: StoryFn<NggvFoldOutComponent> = (args: any) => {
   return {
     template: /* html */ `
       <div class="story-wrapper--right-align">
-        <nggv-fold-out [alignOptions]="alignOptions">
+        <nggv-fold-out [alignOptions]="alignOptions" [listWidth]="listWidth">
           <div nggvOption (click)="lastClicked = 'View details'">View details</div>
           <div nggvOption (click)="lastClicked = 'Sign payment'">Sign payment</div>
           <div nggvOption class="delete-option" (click)="lastClicked = 'Delete'">Delete</div>
@@ -67,7 +79,7 @@ const TemplateWithText: StoryFn<NggvFoldOutComponent> = (args: any) => {
   return {
     template: /* html */ `
       <div class="story-wrapper">
-        <nggv-fold-out [text]="text">
+        <nggv-fold-out [text]="text" [listWidth]="listWidth">
           <div nggvOption (click)="lastClicked = 'View details'">View details</div>
           <div nggvOption (click)="lastClicked = 'Sign payment'">Sign payment</div>
           <div nggvOption class="delete-option" (click)="lastClicked = 'Delete'">Delete</div>
@@ -82,6 +94,7 @@ const TemplateWithText: StoryFn<NggvFoldOutComponent> = (args: any) => {
 export const Primary = Template.bind({})
 Primary.args = {
   alignOptions: 'left',
+  listWidth: 'fit-content',
 }
 Primary.parameters = {
   docs: { source: { code: examplePrimary } },
@@ -90,6 +103,7 @@ Primary.parameters = {
 export const Alternative = TemplateAlt.bind({})
 Alternative.args = {
   alignOptions: 'right',
+  listWidth: 'fit-content',
 }
 Alternative.parameters = {
   docs: { source: { code: exampleAlt } },
@@ -98,6 +112,7 @@ Alternative.parameters = {
 export const WithText = TemplateWithText.bind({})
 WithText.args = {
   text: 'More',
+  listWidth: 'fit-content',
 }
 WithText.parameters = {
   docs: { source: { code: exampleAlt } },

--- a/libs/angular/src/v-angular/modal/modal.types.ts
+++ b/libs/angular/src/v-angular/modal/modal.types.ts
@@ -2,4 +2,5 @@ export interface DialogButtons {
   positive?: string | null
   neutral?: string | null
   negative?: string | null
+  danger?: string | null
 }


### PR DESCRIPTION
## What has changed?
### nggv-fold-out
- Added `listWidth` property to `fold-out` component. This is mainly to be able to accommodate if the list is wider than the actual component, resulting in unwanted line breaks.
- Options `fit-content`, `max-content`, `min-content`, `auto` for flexibility
- Defaults to `fit-content`, which is how it was previously

`<nggv-fold-out style="width: 30px;">` **width: fit-content**
<img width="110" height="232" alt="image" src="https://github.com/user-attachments/assets/74f53173-1622-47a5-b5f9-bdb98baf48ae" />
`<nggv-fold-out style="width: 30px;" listWidth="max-content">` **width: max-content**
<img width="141" height="185" alt="image" src="https://github.com/user-attachments/assets/82cf9e7c-e1a1-4b48-b8f8-f4801b069287" />

---
### nggv-dialog
- Added new submit button `danger` to `dialog` component. Has priority 2 of 4 (less than "regular" submit, more than "alternatives")
- Changed name of old class of `danger` to `danger-confirm`, to be able to give class name `danger` to new button

**Old**
<img width="389" height="368" alt="image" src="https://github.com/user-attachments/assets/558c6d49-e241-447b-bad4-b704ba16e955" />

**New**
<img width="392" height="371" alt="image" src="https://github.com/user-attachments/assets/36a5542d-259f-4034-b998-cf9d7ceccc4c" />
