### PR TITLE
Toast: Full width on mobile

### DIFF
--- a/.changeset/thin-walls-lie.md
+++ b/.changeset/thin-walls-lie.md
@@ -2,4 +2,4 @@
 '@sebgroup/green-angular': minor
 ---
 
-Changed nggv-toast to full width on smallest breakpoint
+**V-Angular:** Changed nggv-toast to full width on smallest breakpoint

--- a/.changeset/thin-walls-lie.md
+++ b/.changeset/thin-walls-lie.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': minor
+---
+
+Changed nggv-toast to full width on smallest breakpoint

--- a/libs/angular/src/v-angular/toast/toast.component.scss
+++ b/libs/angular/src/v-angular/toast/toast.component.scss
@@ -1,3 +1,5 @@
+@use '@sebgroup/chlorophyll/scss/common';
+
 :host {
   .messages-container {
     position: fixed;
@@ -14,6 +16,11 @@
     min-height: 3rem;
     box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
     margin-top: 1rem;
+
+    @include common.media-breakpoint-down('sm') {
+      max-width: calc(100vw - 2rem);
+      min-width: calc(100vw - 2rem);
+    }
   }
 
   .content {
@@ -75,6 +82,10 @@
       &:hover {
         background-color: #dedede;
       }
+    }
+
+    @include common.media-breakpoint-down('sm') {
+      min-width: auto;
     }
   }
 


### PR DESCRIPTION
CX required changes after design implementation review [PGP-51554](https://jira-general.sebank.se/browse/PGP-51554)

Before:
<img width="255" height="61" alt="image" src="https://github.com/user-attachments/assets/6e7b0173-d4d8-4a34-bc48-d4781c87a70f" />

After this PR changes:
<img width="256" height="63" alt="image" src="https://github.com/user-attachments/assets/5bd8e905-0131-488a-b44c-85ef26bf20d9" />

