### PR TITLE
bugfix: Slider - Text Input and Slider not reading the same value in screen reader when step is not 1.

### DIFF
--- a/.changeset/bright-drinks-walk.md
+++ b/.changeset/bright-drinks-walk.md
@@ -1,0 +1,6 @@
+---
+'@sebgroup/green-angular': patch
+'@sebgroup/green-react': patch
+---
+
+bugfix: Slider - fix accessibility issue when text input is not following the steps.

--- a/libs/angular/src/lib/slider/slider.component.html
+++ b/libs/angular/src/lib/slider/slider.component.html
@@ -26,6 +26,7 @@
   [disabled]="disabled"
   [(ngModel)]="value"
   [ngStyle]="style"
+  [attr.aria-valuenow]="value"
   (blur)="onBlur()"
   (input)="handleChange()"
 />

--- a/libs/angular/src/lib/slider/slider.component.ts
+++ b/libs/angular/src/lib/slider/slider.component.ts
@@ -83,7 +83,8 @@ export class NggSliderComponent
   }
 
   handleChange(): void {
-    this.value = this.value ?? 0
+    this.value =
+      this.value && this.value.toString() !== '' ? this.value : this.min
     this.setTrackBackground()
     this.sliderChange.emit(this.value)
     this.onChangeFn && this.onChangeFn(this.value)

--- a/libs/angular/src/lib/slider/slider.component.ts
+++ b/libs/angular/src/lib/slider/slider.component.ts
@@ -95,7 +95,10 @@ export class NggSliderComponent
       return
     }
 
-    const percent = ((this.value - this.min) / (this.max - this.min)) * 100
+    const percent =
+      (Math.round((this.value - this.min) / this.step) /
+        ((this.max - this.min) / this.step)) *
+      100
     this.style.background = getSliderTrackBackground(percent)
   }
 

--- a/libs/angular/src/lib/slider/slider.stories.ts
+++ b/libs/angular/src/lib/slider/slider.stories.ts
@@ -94,10 +94,13 @@ const Template: StoryFn<NggSliderComponent> = (args) => {
   return {
     template: `
       <ngg-slider
-        label="Slider label text in one line"
-        instruction="Element instruction"
+        [label]="label"
+        [instruction]="instruction"
         placeholder="%"
-        [value]="50"
+        [value]="defaultValue"
+        [min]="min"
+        [max]="max"
+        [step]="step"
         [hasTextbox]="hasTextbox"
         [unitLabel]="unitLabel"
         [disabled]="disabled"
@@ -111,27 +114,43 @@ const Template: StoryFn<NggSliderComponent> = (args) => {
   }
 }
 
+const DefaultArgs = {
+  label: 'Slider label text in one line',
+  instruction: 'Element instruction',
+  defaultValue: 50,
+  min: 0,
+  max: 100,
+  step: 1,
+}
+
 export const Default = Template.bind({})
+Default.args = {
+  ...DefaultArgs,
+}
 
 export const Textbox = Template.bind({})
 Textbox.args = {
   hasTextbox: true,
+  ...DefaultArgs,
 }
 
 export const UnitTextbox = Template.bind({})
 UnitTextbox.args = {
   hasTextbox: true,
   unitLabel: 'kr',
+  ...DefaultArgs,
 }
 
 export const Error = Template.bind({})
 Error.args = {
   hasTextbox: true,
   errorMessage: 'Error text can be quite long',
+  ...DefaultArgs,
 }
 
 export const Disabled = Template.bind({})
 Disabled.args = {
   hasTextbox: true,
   disabled: true,
+  ...DefaultArgs,
 }

--- a/libs/react/src/lib/slider/slider.spec.tsx
+++ b/libs/react/src/lib/slider/slider.spec.tsx
@@ -63,6 +63,7 @@ describe('Slider', () => {
       rerender(<Slider value={200} />)
     })
     expect(input.value).toBe('100')
+    expect(input.getAttribute('aria-valuenow')).toEqual('100')
   })
 
   it('should clamp to min value', () => {
@@ -72,6 +73,7 @@ describe('Slider', () => {
       rerender(<Slider value={-10} />)
     })
     expect(input.value).toBe('0')
+    expect(input.getAttribute('aria-valuenow')).toEqual('0')
   })
 
   it('should fire onClamp', () => {
@@ -100,5 +102,25 @@ describe('Slider', () => {
     ) as HTMLInputElement
     fireEvent.blur(inputField, { target: { value: '' } })
     expect(onChange).toBeCalledWith(10)
+  })
+
+  it('should have same aria value when input field is set without following the step', () => {
+    const onChange = jest.fn()
+    const { container } = render(
+      <Slider
+        label={'label'}
+        hasTextbox={true}
+        value={50}
+        min={0}
+        max={1000}
+        step={100}
+        onChange={onChange}
+      />,
+    )
+    const slider = container.querySelector(
+      'input[type=range]',
+    ) as HTMLInputElement
+    expect(slider.getAttribute('aria-valuenow')).toEqual('50')
+    expect(slider.value).toEqual('50')
   })
 })

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -67,7 +67,8 @@ export function Slider({
 
     let percent = 0
     if (sliderValue !== undefined)
-      percent = ((sliderValue - min) / (max - min)) * 100
+      percent =
+        (Math.round((sliderValue - min) / step) / ((max - min) / step)) * 100
 
     setBackground(getSliderTrackBackground(percent))
   }, [disabled, sliderValue])

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -161,6 +161,7 @@ export function Slider({
         step={step}
         disabled={disabled}
         onChange={(e) => handleChange(e.currentTarget.value)}
+        aria-valuenow={sliderValue || 0}
         style={{
           background,
         }}


### PR DESCRIPTION
closes #1843

This PR should allow the screen reader read the same value as in the input text if it used value that is not following the step.
Fixed the angular slider storybook in the same time. 