### PR TITLE
Make `GlobalStylesRegistry` version scoped

### DIFF
--- a/.changeset/unlucky-laws-serve.md
+++ b/.changeset/unlucky-laws-serve.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**GlobalStyles:** Make `GlobalStylesRegistry` version scoped

--- a/libs/core/src/utils/global-styles.ts
+++ b/libs/core/src/utils/global-styles.ts
@@ -1,10 +1,11 @@
 import { CSSResult } from 'lit'
 
+import { VER_SUFFIX } from '../scoping'
 import { supportsConstructedStylesheets } from '../utils/controllers/dynamic-styles-controller'
 import { isServer } from './helpers/platform'
 
 declare global {
-  var __gdsGlobalStylesRegistry: GlobalStylesRegistry // eslint-disable-line no-var
+  var __gdsGlobalStylesRegistry: { [VER_SUFFIX]: GlobalStylesRegistry } // eslint-disable-line no-var
 }
 
 function getDocumentAdoptedStylesheet() {
@@ -12,6 +13,10 @@ function getDocumentAdoptedStylesheet() {
   return document.adoptedStyleSheets || []
 }
 
+/**
+ * GlobalStylesRegistry is a singleton class that manages global stylesheets in the document.
+ * The singleton is used to inject global styles that are not scoped to specific components.
+ */
 export class GlobalStylesRegistry {
   #useLegacyStylesheets = !supportsConstructedStylesheets()
   #styleSheets = new Map<string, CSSStyleSheet>()
@@ -22,10 +27,13 @@ export class GlobalStylesRegistry {
    * Get the global singleton instance of the GlobalStylesRegistry.
    */
   static get instance() {
-    if (!globalThis.__gdsGlobalStylesRegistry)
-      globalThis.__gdsGlobalStylesRegistry = new GlobalStylesRegistry()
+    if (!globalThis.__gdsGlobalStylesRegistry?.[VER_SUFFIX])
+      globalThis.__gdsGlobalStylesRegistry = {
+        ...globalThis.__gdsGlobalStylesRegistry,
+        [VER_SUFFIX]: new GlobalStylesRegistry(),
+      }
 
-    return globalThis.__gdsGlobalStylesRegistry
+    return globalThis.__gdsGlobalStylesRegistry[VER_SUFFIX]
   }
 
   /**


### PR DESCRIPTION
This PR makes the GlobalStylesRegistry, used to inject global styles to the document root, version scoped. This means that different versions of green will not overwrite each others global styles. Instead, both style instances will be present and managed in separate registries.