### PR TITLE
Fix JVM tokens format

### DIFF
--- a/.changeset/big-coats-fry.md
+++ b/.changeset/big-coats-fry.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-tokens': patch
+---
+
+Fix bad syntax in enum-class template

--- a/libs/tokens/src/templates/jvm/enum-class.template.js
+++ b/libs/tokens/src/templates/jvm/enum-class.template.js
@@ -16,4 +16,4 @@ ${allTokens
       `    ${token.comment ? `/** ${token.comment} */\n  ` : ''}${options.accessControl ? `${options.accessControl} ` : ''}${camelToUpperSnake(token.name.replace('sysColor', ''))},`,
   )
   .join('\n')}
-)\n`
+}\n`


### PR DESCRIPTION
Fix a typo in the template where a ")" was used instead of a "}"