### PR TITLE
Pagination+Alert: Color fix

### DIFF
--- a/.changeset/large-llamas-impress.md
+++ b/.changeset/large-llamas-impress.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/chlorophyll': patch
+---
+
+**Pagination:** Selected color fix

--- a/.changeset/large-llamas-impress.md
+++ b/.changeset/large-llamas-impress.md
@@ -3,3 +3,4 @@
 ---
 
 **Pagination:** Selected color fix
+**Alert:** Success color fix

--- a/libs/chlorophyll/scss/components/alert-ribbon/_mixins.scss
+++ b/libs/chlorophyll/scss/components/alert-ribbon/_mixins.scss
@@ -15,7 +15,7 @@ $variants: (
     ghost-button-type: 'light',
   ),
   'success': (
-    color: var(--gds-sys-color-base-000),
+    color: var(--gds-sys-color-white),
     border-color: transparent,
     link-outline-color:
       hsla(var(--sg-intent-success-hsl-contrast), link.$outline-opacity),

--- a/libs/chlorophyll/scss/components/alert-ribbon/_mixins.scss
+++ b/libs/chlorophyll/scss/components/alert-ribbon/_mixins.scss
@@ -15,7 +15,7 @@ $variants: (
     ghost-button-type: 'light',
   ),
   'success': (
-    color: var(--gds-sys-color-white),
+    color: var(--gds-sys-color-text-inverted),
     border-color: transparent,
     link-outline-color:
       hsla(var(--sg-intent-success-hsl-contrast), link.$outline-opacity),

--- a/libs/chlorophyll/scss/components/pagination/_mixins.scss
+++ b/libs/chlorophyll/scss/components/pagination/_mixins.scss
@@ -50,7 +50,7 @@
 
     &[aria-current] {
       background: var(--gds-sys-color-base-800);
-      color: var(--gds-sys-color-white);
+      color: var(--gds-sys-color-text-inverted);
       font-weight: 500;
     }
 

--- a/libs/chlorophyll/scss/components/pagination/_mixins.scss
+++ b/libs/chlorophyll/scss/components/pagination/_mixins.scss
@@ -50,7 +50,7 @@
 
     &[aria-current] {
       background: var(--gds-sys-color-base-800);
-      color: var(--gds-sys-color-base-000);
+      color: var(--gds-sys-color-white);
       font-weight: 500;
     }
 


### PR DESCRIPTION
Was black color on black background for the selected tab in pagination.
Bug reported in GDS->General.

Color base-000 is not used and becomes black.

Edit: Same error in Alert success. Should be white text on green, not black text on green. Checked the old design.