### PR TITLE
Revert "V-Angular Dropdown: move dropdown list to CDK portal (#2411)"

### DIFF
--- a/.changeset/long-frogs-cry.md
+++ b/.changeset/long-frogs-cry.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': minor
+---
+
+Revert moving v-angular dropdown-list to CDK portal

--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -2,6 +2,3 @@
 @use '@sebgroup/chlorophyll/scss' with (
   $font-path: '@sebgroup/fonts/fonts'
 );
-
-// used for v-angular dropdown
-@import '@angular/cdk/overlay-prebuilt.css';

--- a/libs/angular/src/v-angular/dropdown/dropdown-list/dropdown-list.component.html
+++ b/libs/angular/src/v-angular/dropdown/dropdown-list/dropdown-list.component.html
@@ -3,7 +3,6 @@
   <ul
     class="gds-dropdown__options card options gds-reset"
     [class.gds-dropdown__options-expanded]="expanded"
-    [class.use-margin]="useMargin"
     role="listbox"
     tabindex="-1"
     [attr.data-thook]="thook + '-options'"

--- a/libs/angular/src/v-angular/dropdown/dropdown-list/dropdown-list.component.scss
+++ b/libs/angular/src/v-angular/dropdown/dropdown-list/dropdown-list.component.scss
@@ -15,14 +15,16 @@
   --sg-popover-box-shadow: 0 0.125rem 0.375rem rgba(0, 0, 0, 0.15);
   --text-primary-color: #333;
 
+  position: absolute;
   bottom: 0;
-  width: 100%; 
+  transform: translateY(calc(100% + 0.5rem));
   z-index: var(--sg-z-index-dropdown);
 
   .visually-hidden:not(:focus):not(:active) {
     clip-path: inset(50%);
     height: 1px;
     overflow: hidden;
+    position: absolute;
     white-space: nowrap;
     width: 1px;
   }
@@ -52,10 +54,6 @@
     overflow-y: auto;
     width: 100%;
     overscroll-behavior: none;
-
-    &.use-margin {
-      margin-top: 0.5rem 0rem;
-    }
 
     @include common.padding-bottom(0);
     @include common.add-border();
@@ -128,5 +126,15 @@
     background-color: #e7e7e7;
     padding-inline: 1rem;
     padding-block: 0.5rem;
+  }
+
+  &[data-position='top'] {
+    top: auto;
+    bottom: 100%;
+    transform: translateY(-0.5rem);
+  }
+  &[data-position='bottom'] {
+    bottom: 0;
+    transform: translateY(calc(100% + 0.5rem));
   }
 }

--- a/libs/angular/src/v-angular/dropdown/dropdown-list/dropdown-list.component.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown-list/dropdown-list.component.ts
@@ -57,10 +57,6 @@ export class NggvDropdownListComponent implements OnInit, OnChanges {
   @HostBinding('attr.data-thook') @Input() thook: string | null | undefined =
     'dropdown'
 
-  /**
-   * @deprecated This attribute is no longer used. The dropdown position is now handled by Angular CDK Overlay.
-   * Will be removed in a future release.
-   */
   @HostBinding('attr.data-position') get positionAttr() {
     return this.dropdownPosition
   }
@@ -84,24 +80,10 @@ export class NggvDropdownListComponent implements OnInit, OnChanges {
   @Input() selectWithSpace = true
 
   /**
-   * @deprecated This input is no longer used. The dropdown now always chooses position dynamically.
-   * Will be removed in a future release.
+   * When true, the dropdown will automatically choose to open above or below the input
+   * based on available space in the viewport, and will scale its height to fit if needed.
    */
   @Input() dynamicPosition = false
-
-  /**
-   * Stores the bounding rectangle of the dropdown trigger element,
-   * used for positioning the dropdown list overlay.
-   */
-  @Input() triggerRect?: DOMRect
-
-  /**
-   * Controls whether the dropdown list should have a vertical margin.
-   * Set to false when the dropdown list is rendered in a CDK overlay and spacing is handled by overlay offset.
-   * Set to true when the dropdown list is used standalone or in other micro frontends, so it maintains visual spacing.
-   * Defaults to true.
-   */
-  @Input() useMargin = true
 
   @Output() selectedValueChanged = new EventEmitter<any>()
 
@@ -112,10 +94,7 @@ export class NggvDropdownListComponent implements OnInit, OnChanges {
 
   scope: string | undefined
 
-  /**
-   * @deprecated This attribute is no longer used. The dropdown position is now handled by Angular CDK Overlay.
-   * Will be removed in a future release.
-   */
+  // Indicates whether the dropdown list should be displayed below ('bottom') or above ('top') the input, based on available space.
   dropdownPosition: 'bottom' | 'top' = 'bottom'
 
   private dropdownUtils: DropdownUtils<string | null, string, any> =
@@ -188,9 +167,9 @@ export class NggvDropdownListComponent implements OnInit, OnChanges {
     this._expanded = expanded
 
     if (expanded) {
-      setTimeout(() => {
-        this.setDropdownHeight()
-      }, 0)
+      if (this.dynamicPosition) {
+        this.setDropdownPosition()
+      }
       this.refreshSelectedOption()
       this.subscribeToKeyUpEvents()
       this.subscribeToKeyDownEvents()
@@ -402,14 +381,15 @@ export class NggvDropdownListComponent implements OnInit, OnChanges {
 
   /**
    * Calculates available space above and below the dropdown input,
+   * sets dropdownPosition ('top' or 'bottom') accordingly,
    * and dynamically sets the max-height of the dropdown list to fit the viewport.
    */
-  setDropdownHeight() {
+  setDropdownPosition() {
     const dropdown = this.elRef.nativeElement
+    // dropdown trigger
+    const dropdownInput = dropdown.parentElement
     const dropdownList = dropdown.querySelector('ul[role="listbox"]')
-    const rect = this.triggerRect
-
-    if (!rect || !dropdownList) return
+    const rect = dropdownInput.getBoundingClientRect()
 
     const viewportHeight = window.innerHeight
     const spaceBelow = viewportHeight - rect.bottom
@@ -421,16 +401,19 @@ export class NggvDropdownListComponent implements OnInit, OnChanges {
     let maxDropdownHeight
 
     if (spaceBelow >= DROPDOWN_MAX_HEIGHT) {
+      this.dropdownPosition = 'bottom'
       maxDropdownHeight = DROPDOWN_MAX_HEIGHT
     } else if (spaceAbove >= DROPDOWN_MAX_HEIGHT) {
+      this.dropdownPosition = 'top'
       maxDropdownHeight = DROPDOWN_MAX_HEIGHT
     } else if (spaceBelow > spaceAbove) {
-      maxDropdownHeight = Math.max(spaceBelow - MARGIN, MIN_HEIGHT)
+      this.dropdownPosition = 'bottom'
+      maxDropdownHeight = Math.max(spaceBelow - MARGIN, MIN_HEIGHT) // 10px margin, minimum height 100px
     } else {
-      maxDropdownHeight = Math.max(spaceAbove - MARGIN, MIN_HEIGHT)
+      this.dropdownPosition = 'top'
+      maxDropdownHeight = Math.max(spaceAbove - MARGIN, MIN_HEIGHT) // 10px margin, minimum height 100px
     }
 
     this.renderer.setStyle(dropdownList, 'max-height', `${maxDropdownHeight}px`)
-    this.renderer.setStyle(dropdownList, 'overflow-y', 'auto')
   }
 }

--- a/libs/angular/src/v-angular/dropdown/dropdown.component.html
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.html
@@ -62,7 +62,6 @@
     <div class="gds-input-wrapper dropdown-wrapper">
       <div #input [id]="id + '-input'" class="dropdown">
         <button
-          #toggleButton
           [id]="id + '-toggle'"
           [disabled]="disabled"
           type="button"
@@ -90,25 +89,22 @@
             </ng-template>
           </span>
         </button>
-        <ng-template #dropdownTemplate>
-          <nggv-dropdown-list
-            #dropDownList
-            [options]="options"
-            [scrollOffset]="scrollOffset"
-            [state]="state"
-            [expanded]="expanded"
-            [optionContentTpl]="optionContentTpl"
-            [groupLabelTpl]="groupLabelTpl"
-            [textToHighlight]="textToHighlight"
-            [onlyEmitDistinctChanges]="onlyHandleDistinctChanges"
-            [selectWithSpace]="selectWithSpace"
-            [triggerRect]="triggerRect"
-            [useMargin]="false"
-            (closed)="setExpanded(false)"
-            (selectedValueChanged)="onSelectChange($event)"
-          >
-          </nggv-dropdown-list>
-        </ng-template>
+        <nggv-dropdown-list
+          #dropDownList
+          [options]="options"
+          [scrollOffset]="scrollOffset"
+          [state]="state"
+          [expanded]="expanded"
+          [optionContentTpl]="optionContentTpl"
+          [groupLabelTpl]="groupLabelTpl"
+          [textToHighlight]="textToHighlight"
+          [onlyEmitDistinctChanges]="onlyHandleDistinctChanges"
+          [selectWithSpace]="selectWithSpace"
+          [dynamicPosition]="true"
+          (closed)="setExpanded(false)"
+          (selectedValueChanged)="onSelectChange($event)"
+        >
+        </nggv-dropdown-list>
       </div>
       <!-- ERRORS -->
       <div class="gds-form-item__footer error-wrapper">

--- a/libs/angular/src/v-angular/dropdown/dropdown.component.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.ts
@@ -1,25 +1,33 @@
+import '@sebgroup/green-core/components/icon/icons/triangle-exclamation.js'
 
+import {
+  ChangeDetectorRef,
+  Component,
+  ContentChild,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Inject,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Optional,
+  Output,
+  Self,
+  SimpleChanges,
+  TemplateRef,
+} from '@angular/core'
+import { NgControl } from '@angular/forms'
+import { TRANSLOCO_SCOPE, TranslocoScope } from '@jsverse/transloco'
+import { fromEvent, Subscription } from 'rxjs'
 
-
-import '@sebgroup/green-core/components/icon/icons/triangle-exclamation.js';
-
-
-
-import { ConnectedPosition, Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
-import { TemplatePortal } from '@angular/cdk/portal';
-import { ChangeDetectorRef, Component, ContentChild, ElementRef, EventEmitter, HostBinding, HostListener, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
-import { NgControl } from '@angular/forms';
-import { TRANSLOCO_SCOPE, TranslocoScope } from '@jsverse/transloco';
-import { fromEvent, Subscription } from 'rxjs';
-
-
-
-import { NggvBaseControlValueAccessorComponent } from '@sebgroup/green-angular/src/v-angular/base-control-value-accessor';
-import { DropdownUtils, Option, OptionBase, OptionGroup } from '@sebgroup/green-angular/src/v-angular/core';
-
-
-
-
+import { NggvBaseControlValueAccessorComponent } from '@sebgroup/green-angular/src/v-angular/base-control-value-accessor'
+import {
+  DropdownUtils,
+  Option,
+  OptionBase,
+  OptionGroup,
+} from '@sebgroup/green-angular/src/v-angular/core'
 
 /**
  * A dropdown allows the user to select an option from a list.
@@ -63,11 +71,6 @@ export class NggvDropdownComponent<
   @HostBinding('class.large') get isLarge(): boolean {
     return this.size === 'large'
   }
-
-  /** Reference to the dropdown list template used for rendering the dropdown in an overlay. */
-  @ViewChild('dropdownTemplate') dropdownTemplate!: TemplateRef<any>
-  // Used for positioning and sizing the dropdown overlay relative to the trigger button.
-  @ViewChild('toggleButton', { read: ElementRef }) toggleButton!: ElementRef
 
   /**
    * Sets the displayed size of the dropdown.
@@ -148,12 +151,6 @@ export class NggvDropdownComponent<
   @Input() onlyHandleDistinctChanges = true
 
   /**
-   * If true (default), the dropdown list will close when any scrollable ancestor is scrolled.
-   * If false, the dropdown list will reposition itself instead of closing.
-   */
-  @Input() closeDropdownListOnScroll = true
-
-  /**
    * Emits changes of the expanded state of the dropdown
    */
   @Output() expandedChange = new EventEmitter<boolean>()
@@ -167,24 +164,13 @@ export class NggvDropdownComponent<
   public expanded = false
   /** The current option selected based on numeric index. */
   public activeIndex = -1
-  /**
-   * Stores the bounding rectangle of the dropdown trigger element,
-   * used for positioning the dropdown list overlay.
-   */
-  public triggerRect: DOMRect | undefined = undefined
   /** Subscribe if dropdown expanded to listen to click outside to close dropdown. */
   private onClickSubscription: Subscription | undefined
   /** Subscribe if dropdown expanded to listen to scroll outside to close dropdown. */
   private onScrollSubscription: Subscription | undefined
-  /** Subscribe to get dropdown width size changes for a dropdown list width to match. */
-  private resizeSubscription: Subscription | undefined
-  /** Subscription to dropdown list overlay detachments. */
-  private overlayDetachSubscription: Subscription | undefined
 
   public keyEvent: KeyboardEvent = {} as KeyboardEvent
   private _options: OptionBase<T>[] = []
-  /** Reference to the currently attached dropdown list overlay. Used for opening/closing and positioning. */
-  private overlayRef?: OverlayRef
 
   constructor(
     @Self() @Optional() public ngControl: NgControl,
@@ -193,8 +179,6 @@ export class NggvDropdownComponent<
     protected translocoScope: TranslocoScope,
     protected cdr: ChangeDetectorRef,
     protected dropdownUtils: DropdownUtils<K, V, T>,
-    protected overlay: Overlay,
-    protected vcr: ViewContainerRef,
   ) {
     super(ngControl, translocoScope, cdr)
   }
@@ -221,8 +205,6 @@ export class NggvDropdownComponent<
   ngOnDestroy(): void {
     this.onClickSubscription?.unsubscribe()
     this.onScrollSubscription?.unsubscribe()
-    this.resizeSubscription?.unsubscribe()
-    this.overlayDetachSubscription?.unsubscribe()
   }
 
   /** @internal override to correctly set state from form value */
@@ -268,6 +250,19 @@ export class NggvDropdownComponent<
       },
     })
   }
+  subscribeToOutsideScrollEvent() {
+    this.onScrollSubscription = fromEvent(document, 'scroll').subscribe({
+      next: (event: Event) => {
+        if (
+          this.expanded &&
+          !this.inputRef?.nativeElement.contains(event.target)
+        ) {
+          this.toggleDropdown()
+          this.onScrollSubscription?.unsubscribe()
+        }
+      },
+    })
+  }
 
   // ----------------------------------------------------------------------------
   // HELPERS
@@ -297,111 +292,10 @@ export class NggvDropdownComponent<
     this.expanded = state
     this.expandedChange.emit(this.expanded)
     if (this.expanded) {
-      this.openDropdownOverlay()
       this.subscribeToOutsideClickEvent()
-    } else {
-      this.closeDropdownOverlay()
-      this.onTouched()
+      this.subscribeToOutsideScrollEvent()
     }
-  }
-
-  /**
-   * Opens the dropdown overlay by detaching any existing overlay reference,
-   * attaching a new overlay, updating its width, and setting up listeners for overlay detachments.
-   * This method ensures the dropdown overlay is properly initialized and displayed.
-   */
-  openDropdownOverlay() {
-    this.detachOldOverlayRef()
-    this.attachNewOverlayRef()
-    this.updateOverlayWidth()
-    this.listenOverlayDetachments()
-  }
-
-  detachOldOverlayRef(): void {
-    if (this.overlayRef) {
-      this.overlayRef.detach()
-    }
-  }
-
-  attachNewOverlayRef(): void {
-    const positionStrategy = this.overlay
-      .position()
-      .flexibleConnectedTo(this.toggleButton)
-      .withPositions(this.getDropdownListPositionsArray())
-      .withPush(false) // Prevent overlay from overlapping the trigger
-
-    this.overlayRef = this.overlay.create({
-      positionStrategy,
-      scrollStrategy: this.getScrollStrategy(),
-    })
-
-    // Get trigger rect and pass to dropdown-list
-    this.triggerRect = this.toggleButton.nativeElement.getBoundingClientRect()
-
-    this.overlayRef.attach(new TemplatePortal(this.dropdownTemplate, this.vcr))
-  }
-
-  updateOverlayWidth(): void {
-    // sets initial width to match trigger element
-    this.setOverlayWidth()
-
-    // Listen for window resize and update overlay width
-    this.resizeSubscription = fromEvent(window, 'resize').subscribe(() => {
-      this.setOverlayWidth()
-    })
-  }
-
-  // used to catch when overlay is detached after scroll with list expanded
-  listenOverlayDetachments() {
-    if (this.overlayRef) {
-      this.overlayDetachSubscription = this.overlayRef
-        .detachments()
-        .subscribe(() => {
-          if (this.expanded) {
-            this.setExpanded(false)
-          }
-        })
-    }
-  }
-
-  getDropdownListPositionsArray(): ConnectedPosition[] {
-    return [
-      {
-        originX: 'start',
-        originY: 'bottom',
-        overlayX: 'start',
-        overlayY: 'top',
-        offsetY: 8, // 0.5rem gap below the trigger
-      },
-      {
-        originX: 'start',
-        originY: 'top',
-        overlayX: 'start',
-        overlayY: 'bottom',
-        offsetY: -8, // 0.5rem gap above the trigger
-      },
-    ]
-  }
-
-  getScrollStrategy(): ScrollStrategy {
-    return this.closeDropdownListOnScroll
-      ? this.overlay.scrollStrategies.close()
-      : this.overlay.scrollStrategies.reposition()
-  }
-
-  setOverlayWidth() {
-    if (this.overlayRef && this.toggleButton) {
-      const buttonWidth = this.toggleButton.nativeElement.offsetWidth
-      const pane = this.overlayRef.overlayElement as HTMLElement
-
-      pane.style.width = `${buttonWidth}px`
-    }
-  }
-
-  closeDropdownOverlay() {
-    this.overlayRef?.detach()
-    this.resizeSubscription?.unsubscribe()
-    this.overlayDetachSubscription?.unsubscribe()
+    if (!this.expanded) this.onTouched()
   }
 
   /* TYPE CASTS */

--- a/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
@@ -141,9 +141,6 @@ const Template: StoryFn<NggvDropdownComponent> = (args: any) => {
         <div style="margin-top: 1rem">
           <button type="button" class="gds-button" (click)="disableFn()">Toggle disable control</button>
         </div>
-        <div style="margin-top: 1rem; background: #fff3cd; color: #856404; padding: 1rem; margin-bottom: 1rem; border-radius: 4px;">
-          ⚠️ <b>Note:</b> For a dropdown list to work correctly in your app or MFE, you must import <code>&#64;angular/cdk/overlay-prebuilt.css</code> in your global stylesheet.
-        </div>
       </div>`,
     props: {
       ...args,


### PR DESCRIPTION
In consumer project green-core is not updated to the newest version (V2).
Also, in the consumer project there is an additional styling for the dropdowns applied, so this change with portal breaks styling in the consumer project and to fix, it will require time.

To handle green migration to v2 correctly, this change will be reverted for now.