### PR TITLE
Checkbox: Fix tree-shaking issue

### DIFF
--- a/.changeset/four-guests-roll.md
+++ b/.changeset/four-guests-roll.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Checkbox:** Fix tree-shaking issue that sometimes happens with Angular

--- a/libs/core/src/components/checkbox/checkbox.component.ts
+++ b/libs/core/src/components/checkbox/checkbox.component.ts
@@ -8,7 +8,8 @@ import { checkboxToggle } from '../../shared-styles/rbcb-toggle.template'
 import { tokens } from '../../tokens.style'
 import { watch } from '../../utils/decorators/watch'
 import { GdsFormControlElement } from '../form/form-control'
-import { IconCheckmark, IconMinusSmall } from '../pure'
+import { IconCheckmark } from '../icon/icons/checkmark.component'
+import { IconMinusSmall } from '../icon/icons/minus-small.component'
 import CheckboxStyles from './checkbox.styles'
 
 /**


### PR DESCRIPTION
This PR fixes an intermittent tree-shaking issue that pos up in Angular from time to time. Seems to happen only when certain combinations of components are imported.

This change fixed the issue in my local test project with Angular 20.