### PR TITLE
Filter chips: Fix initial state issue

### DIFF
--- a/.changeset/many-dragons-return.md
+++ b/.changeset/many-dragons-return.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Filter chips:** Fix initial state issue when multiple mode is used

--- a/libs/core/src/components/filter-chips/filter-chips.component.ts
+++ b/libs/core/src/components/filter-chips/filter-chips.component.ts
@@ -154,9 +154,22 @@ export class GdsFilterChips<ValueT = any> extends GdsFormControlElement<
   }
 
   #handleSlotChange() {
-    const selChipValue = this.chips.find((s) => s.selected)?.value
-    if (selChipValue) {
-      this.value = selChipValue
+    if (this.value === undefined) {
+      if (!this.multiple) {
+        const selChipValue = this.chips.find((s) => s.selected)?.value
+        if (selChipValue) {
+          this.value = selChipValue
+        }
+      } else {
+        const selChipValues = this.chips
+          .filter((s) => s.selected)
+          .map((s) => s.value)
+        if (selChipValues.length) {
+          this.value = selChipValues as ValueT
+        }
+      }
+    } else {
+      this._updateSelectedFromValue()
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where the inital `value` didn't reflect correctly in the rendered state of the component, in particular when using with Angular.