### PR TITLE
chore(core): export tokens.style.js

### DIFF
--- a/.changeset/moody-dancers-flow.md
+++ b/.changeset/moody-dancers-flow.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+chore: export tokens.style.js for consumers to load css variables using js

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -48,6 +48,7 @@
     "./_primitives/*": "./primitives/*",
     "./react": "./generated/react/index.js",
     "./react/*": "./generated/react/*",
-    "./patterns/*": "./patterns/*"
+    "./patterns/*": "./patterns/*",
+    "./tokens": "./tokens.style.js"
   }
 }


### PR DESCRIPTION
Normally, I import any Green Core component (and potentially using GdsTheme if needed) and the CSS variables are loaded through those imported components. 

However I have found that when mixing routing engines (such as doing a full reload vs. doing a client side navigation using e.g. React Router), the tokens are sometimes lost. Could be a race condition or how I am configuring the client (in this case [Docusaurus](https://docusaurus.io/)), but I think it would be solved by always calling the `tokens.style.js` file in a [Docusaurus client module](https://docusaurus.io/docs/advanced/client#client-modules).

Perhaps there could be other use cases for this also? 

The encouraged way to import the tokens should be directly from importing Green Core components or using GdsTheme.